### PR TITLE
Use PHP script for Efí subscription

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ EFIBANK_CLIENT_SECRET=your_client_secret
 EFIBANK_ACCOUNT_ID=your_account_id
 EFIBANK_PIX_KEY=your_pix_key
 EFIBANK_CERTIFICATE_PATH=./certs/efibank.p12
+NEXT_PUBLIC_EFIBANK_ACCOUNT_ID=your_account_id

--- a/pages/api/efibank/admin.ts
+++ b/pages/api/efibank/admin.ts
@@ -11,6 +11,7 @@ import {
   listCharges,
   retryCharge,
   updateSubscription,
+  updateSubscriptionMetadata,
   cancelSubscription
 } from '../../../lib/efibank';
 
@@ -50,6 +51,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         break;
       case 'updateSubscription':
         data = await updateSubscription(params.id, params.body);
+        break;
+      case 'updateSubscriptionMetadata':
+        data = await updateSubscriptionMetadata(params.id, params.body);
         break;
       case 'cancelSubscription':
         data = await cancelSubscription(params.id);

--- a/pages/api/efibank/subscribe.ts
+++ b/pages/api/efibank/subscribe.ts
@@ -14,9 +14,9 @@ function logDebug(msg: string, data?: unknown) {
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).end();
   try {
-    const { plan, customer, card } = req.body;
-    logDebug('API /efibank/subscribe called', { plan, customer });
-    const sub = await createEfibankSubscription(plan, customer, card);
+    const payload = req.body;
+    logDebug('API /efibank/subscribe called', payload);
+    const sub = await createEfibankSubscription(payload);
     logDebug('API /efibank/subscribe success', sub);
     res.status(200).json(sub);
   } catch (err) {

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { Button } from '../components/ui/button';
 import { Card } from '../components/ui/card';
@@ -8,31 +8,86 @@ import { supabase } from '../lib/supabaseClient';
 export default function Checkout() {
   const router = useRouter();
   const { plan, name, email, companyId } = router.query as Record<string, string>;
-  const [card, setCard] = useState({
+  const [form, setForm] = useState({
+    cpf: '',
+    phone: '',
+    brand: '',
     number: '',
-    holder: '',
-    expMonth: '',
-    expYear: '',
-    cvv: ''
+    cvv: '',
+    expiration_month: '',
+    expiration_year: '',
+    street: '',
+    num: '',
+    neighborhood: '',
+    zipcode: '',
+    city: '',
+    state: ''
   });
+  const [checkoutObj, setCheckoutObj] = useState<any>(null);
+
+  useEffect(() => {
+    const id = process.env.NEXT_PUBLIC_EFIBANK_ACCOUNT_ID;
+    if (!id) return;
+    (window as any).$gn = {
+      validForm: true,
+      processed: false,
+      done: {},
+      ready: function (fn: any) {
+        (window as any).$gn.done = fn;
+      }
+    };
+    const s = document.createElement('script');
+    const v = Math.floor(Math.random() * 1000000);
+    s.src = `https://sandbox.gerencianet.com.br/v1/cdn/${id}/${v}`;
+    s.id = id;
+    document.head.appendChild(s);
+    (window as any).$gn.ready((checkout: any) => setCheckoutObj(checkout));
+  }, []);
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
-    setCard({ ...card, [e.target.name]: e.target.value });
+    setForm({ ...form, [e.target.name]: e.target.value });
   };
 
   const handleSubmit = async (
     e: React.FormEvent<HTMLFormElement>
   ) => {
     e.preventDefault();
+    const token: string = await new Promise((resolve, reject) => {
+      if (!checkoutObj) return reject(new Error('checkout not loaded'));
+      checkoutObj.getPaymentToken({
+        brand: form.brand,
+        number: form.number,
+        cvv: form.cvv,
+        expiration_month: form.expiration_month,
+        expiration_year: form.expiration_year
+      }, (err: any, data: any) => {
+        if (err) reject(err); else resolve(data.data.payment_token);
+      });
+    });
+
     const res = await fetch('/api/efibank/subscribe', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        plan,
-        customer: { name, email },
-        card
+        plano: { descricao: plan, interval: 1 },
+        customer: {
+          name,
+          email,
+          cpf: form.cpf,
+          phone_number: form.phone
+        },
+        item: { name: 'Assinatura', amount: 1, value: 1000 },
+        payment_token: token,
+        billing_address: {
+          street: form.street,
+          number: form.num,
+          neighborhood: form.neighborhood,
+          zipcode: form.zipcode,
+          city: form.city,
+          state: form.state
+        }
       })
     });
     const sub = await res.json();
@@ -49,13 +104,19 @@ export default function Checkout() {
       <Card className="w-full max-w-md space-y-4">
         <h1 className="text-xl font-semibold text-center">Checkout do plano {plan}</h1>
         <form onSubmit={handleSubmit} className="space-y-3">
+          <Input name="cpf" placeholder="CPF" onChange={handleChange} />
+          <Input name="phone" placeholder="Telefone" onChange={handleChange} />
+          <Input name="brand" placeholder="Bandeira" onChange={handleChange} />
           <Input name="number" placeholder="Número do cartão" onChange={handleChange} />
-          <Input name="holder" placeholder="Nome do titular" onChange={handleChange} />
-          <div className="flex gap-2">
-            <Input name="expMonth" placeholder="Mês" onChange={handleChange} />
-            <Input name="expYear" placeholder="Ano" onChange={handleChange} />
-            <Input name="cvv" placeholder="CVV" onChange={handleChange} />
-          </div>
+          <Input name="cvv" placeholder="CVV" onChange={handleChange} />
+          <Input name="expiration_month" placeholder="Mês de vencimento" onChange={handleChange} />
+          <Input name="expiration_year" placeholder="Ano de vencimento" onChange={handleChange} />
+          <Input name="street" placeholder="Rua" onChange={handleChange} />
+          <Input name="num" placeholder="Número" onChange={handleChange} />
+          <Input name="neighborhood" placeholder="Bairro" onChange={handleChange} />
+          <Input name="zipcode" placeholder="CEP" onChange={handleChange} />
+          <Input name="city" placeholder="Cidade" onChange={handleChange} />
+          <Input name="state" placeholder="Estado" onChange={handleChange} />
           <Button type="submit" className="w-full">Pagar</Button>
         </form>
       </Card>

--- a/pages/checkoutadmin.tsx
+++ b/pages/checkoutadmin.tsx
@@ -148,6 +148,29 @@ export default function CheckoutAdmin() {
         </form>
       </section>
 
+      <section>
+        <h2 className="font-bold">Atualizar metadados</h2>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            const form = e.currentTarget as any;
+            call('updateSubscriptionMetadata', {
+              id: Number(form.id.value),
+              body: {
+                custom_id: form.customId.value,
+                notification_url: form.url.value
+              }
+            });
+          }}
+          className="space-x-2"
+        >
+          <input name="id" placeholder="Subscription ID" type="number" className="border p-1 w-32" />
+          <input name="customId" placeholder="Custom ID" className="border p-1" />
+          <input name="url" placeholder="Notification URL" className="border p-1 w-64" />
+          <button className="bg-purple-500 text-white px-2 py-1">Atualizar</button>
+        </form>
+      </section>
+
       <pre className="whitespace-pre-wrap bg-gray-100 p-2">{log}</pre>
     </div>
   );


### PR DESCRIPTION
## Summary
- delegate subscription creation to PHP script
- send full subscription data from checkout to backend
- tokenize card data in checkout and debug PHP subscription flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689885477d20832d94a7bbdff76d37fc