### PR TITLE
Use PHP script for Efí subscription

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ EFIBANK_CLIENT_SECRET=your_client_secret
 EFIBANK_ACCOUNT_ID=your_account_id
 EFIBANK_PIX_KEY=your_pix_key
 EFIBANK_CERTIFICATE_PATH=./certs/efibank.p12
+NEXT_PUBLIC_EFIBANK_ACCOUNT_ID=your_account_id

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,17 +1,36 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { LayoutDashboard, Users } from 'lucide-react';
+import { LayoutDashboard, Users, User as UserIcon } from 'lucide-react';
 import { cn } from '../lib/utils';
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabaseClient';
 
 export default function Sidebar() {
   const router = useRouter();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [profile, setProfile] = useState<{ name: string; email: string } | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(async ({ data }) => {
+      const user = data.user;
+      if (user) {
+        const { data: profileData } = await supabase
+          .from('users')
+          .select('name,email')
+          .eq('id', user.id)
+          .single();
+        if (profileData) setProfile(profileData);
+      }
+    });
+  }, []);
+
   const links = [
     { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { href: '/employees', label: 'Funcionários', icon: Users },
   ];
 
   return (
-    <aside className="w-64 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 min-h-screen p-6">
+    <aside className="w-64 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 min-h-screen p-6 flex flex-col">
       <h2 className="text-2xl font-bold text-brand mb-8">Constiva</h2>
       <nav className="flex flex-col space-y-1">
         {links.map(({ href, label, icon: Icon }) => (
@@ -28,6 +47,27 @@ export default function Sidebar() {
           </Link>
         ))}
       </nav>
+      <div className="mt-auto relative">
+        <button
+          onClick={() => setMenuOpen(!menuOpen)}
+          className="flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
+        >
+          <UserIcon className="h-5 w-5" />
+        </button>
+        {menuOpen && profile && (
+          <div className="absolute left-3 right-3 bottom-12 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg p-3 text-sm">
+            <p className="font-medium">{profile.name}</p>
+            <p className="text-xs text-gray-500 mb-2">{profile.email}</p>
+            <Link
+              href="/upgrade"
+              className="block text-brand hover:underline"
+              onClick={() => setMenuOpen(false)}
+            >
+              Upgrade
+            </Link>
+          </div>
+        )}
+      </div>
     </aside>
   );
 }

--- a/lib/efibank.ts
+++ b/lib/efibank.ts
@@ -1,6 +1,8 @@
 import EfiPay from 'gn-api-sdk-node';
 import fs from 'fs';
 import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 
 const DEBUG_PATH = path.join(process.cwd(), 'debugCheckout.txt');
 
@@ -29,55 +31,21 @@ function getClient() {
   });
 }
 
-interface Customer {
-  name: string;
-  email: string;
-}
+const execFileAsync = promisify(execFile);
 
-interface Card {
-  number: string;
-  holder: string;
-  expMonth: string;
-  expYear: string;
-  cvv: string;
-}
-
-export async function createEfibankSubscription(
-  plan: string,
-  customer: Customer,
-  card: Card
-) {
-  logDebug('Starting subscription flow', { plan, customer });
-  const efi = getClient();
-
-  const planBody: any = { name: plan, interval: 1 };
-  const createdPlan = await efi.createPlan({}, planBody);
-  logDebug('Plan created', createdPlan.data);
-
-  const subscription = await efi.createSubscriptionOneStep(
-    { id: createdPlan.data.plan_id },
+export async function createEfibankSubscription(payload: any) {
+  logDebug('Starting subscription via PHP', payload);
+  const { stdout } = (await execFileAsync(
+    'php',
+    ['assinatura-efibank/emitir_assinatura.php'],
     {
-      customer: { name: customer.name, email: customer.email },
-      items: [{ name: 'Assinatura', value: 1000, amount: 1 }],
-      payment: {
-        credit_card: {
-          customer: {
-            name: customer.name,
-            email: customer.email
-          },
-          installments: 1,
-          card_number: card.number,
-          cardholder_name: card.holder,
-          exp_month: card.expMonth,
-          exp_year: card.expYear,
-          security_code: card.cvv
-        }
-      }
-    }
-  );
-  logDebug('Subscription created', subscription.data);
-
-  return subscription.data;
+      input: JSON.stringify(payload),
+      maxBuffer: 1024 * 1024,
+      encoding: 'utf8'
+    } as any
+  )) as unknown as { stdout: string };
+  logDebug('PHP subscription output', stdout);
+  return JSON.parse(stdout);
 }
 
 // ---- Admin helpers ----
@@ -96,7 +64,7 @@ export async function createPlan(name: string, interval: number, repeats?: numbe
 export async function listPlans(params: any = {}) {
   logDebug('listPlans', params);
   const efi = getClient();
-  const resp = await efi.listPlans({}, params);
+  const resp = await efi.getPlans({}, params);
   logDebug('listPlans result', resp.data);
   return resp.data;
 }
@@ -162,6 +130,14 @@ export async function updateSubscription(id: number, body: any) {
   const efi = getClient();
   const resp = await efi.updateSubscription({ id }, body);
   logDebug('updateSubscription result', resp.data);
+  return resp.data;
+}
+
+export async function updateSubscriptionMetadata(id: number, body: any) {
+  logDebug('updateSubscriptionMetadata', { id, body });
+  const efi = getClient();
+  const resp = await efi.updateSubscriptionMetadata({ id }, body);
+  logDebug('updateSubscriptionMetadata result', resp.data);
   return resp.data;
 }
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -6,7 +6,7 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export const PLAN_LIMITS = {
-  basic: 5,
+  free: 5,
   pro: 50,
   enterprise: 500,
 } as const;

--- a/pages/api/efibank/admin.ts
+++ b/pages/api/efibank/admin.ts
@@ -11,6 +11,7 @@ import {
   listCharges,
   retryCharge,
   updateSubscription,
+  updateSubscriptionMetadata,
   cancelSubscription
 } from '../../../lib/efibank';
 
@@ -50,6 +51,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         break;
       case 'updateSubscription':
         data = await updateSubscription(params.id, params.body);
+        break;
+      case 'updateSubscriptionMetadata':
+        data = await updateSubscriptionMetadata(params.id, params.body);
         break;
       case 'cancelSubscription':
         data = await cancelSubscription(params.id);

--- a/pages/api/efibank/subscribe.ts
+++ b/pages/api/efibank/subscribe.ts
@@ -14,9 +14,9 @@ function logDebug(msg: string, data?: unknown) {
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).end();
   try {
-    const { plan, customer, card } = req.body;
-    logDebug('API /efibank/subscribe called', { plan, customer });
-    const sub = await createEfibankSubscription(plan, customer, card);
+    const payload = req.body;
+    logDebug('API /efibank/subscribe called', payload);
+    const sub = await createEfibankSubscription(payload);
     logDebug('API /efibank/subscribe success', sub);
     res.status(200).json(sub);
   } catch (err) {

--- a/pages/checkout.tsx
+++ b/pages/checkout.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { Button } from '../components/ui/button';
 import { Card } from '../components/ui/card';
@@ -8,31 +8,94 @@ import { supabase } from '../lib/supabaseClient';
 export default function Checkout() {
   const router = useRouter();
   const { plan, name, email, companyId } = router.query as Record<string, string>;
-  const [card, setCard] = useState({
+  const [form, setForm] = useState({
+    cpf: '',
+    phone: '',
+    brand: '',
     number: '',
-    holder: '',
-    expMonth: '',
-    expYear: '',
-    cvv: ''
+    cvv: '',
+    expiration_month: '',
+    expiration_year: '',
+    street: '',
+    num: '',
+    neighborhood: '',
+    zipcode: '',
+    city: '',
+    state: ''
   });
+  const [checkoutObj, setCheckoutObj] = useState<any>(null);
+
+  useEffect(() => {
+    const id = process.env.NEXT_PUBLIC_EFIBANK_ACCOUNT_ID;
+    if (!id) return;
+    (window as any).$gn = {
+      validForm: true,
+      processed: false,
+      done: {},
+      ready: function (fn: any) {
+        (window as any).$gn.done = fn;
+      }
+    };
+    const s = document.createElement('script');
+    const v = Math.floor(Math.random() * 1000000);
+    s.src = `https://sandbox.gerencianet.com.br/v1/cdn/${id}/${v}`;
+    s.id = id;
+    document.head.appendChild(s);
+    (window as any).$gn.ready((checkout: any) => setCheckoutObj(checkout));
+  }, []);
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
-    setCard({ ...card, [e.target.name]: e.target.value });
+    setForm({ ...form, [e.target.name]: e.target.value });
   };
 
   const handleSubmit = async (
     e: React.FormEvent<HTMLFormElement>
   ) => {
     e.preventDefault();
+    if (!checkoutObj) {
+      console.error('checkout not loaded');
+      return;
+    }
+
+    const token: string = await new Promise((resolve, reject) => {
+      checkoutObj.getPaymentToken(
+        {
+          brand: form.brand,
+          number: form.number,
+          cvv: form.cvv,
+          expiration_month: form.expiration_month,
+          expiration_year: form.expiration_year,
+        },
+        (err: any, data: any) => {
+          if (err) reject(err);
+          else resolve(data.data.payment_token);
+        }
+      );
+    });
+
     const res = await fetch('/api/efibank/subscribe', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        plan,
-        customer: { name, email },
-        card
+        plano: { descricao: plan, interval: 1 },
+        customer: {
+          name,
+          email,
+          cpf: form.cpf,
+          phone_number: form.phone
+        },
+        item: { name: 'Assinatura', amount: 1, value: 1000 },
+        payment_token: token,
+        billing_address: {
+          street: form.street,
+          number: form.num,
+          neighborhood: form.neighborhood,
+          zipcode: form.zipcode,
+          city: form.city,
+          state: form.state
+        }
       })
     });
     const sub = await res.json();
@@ -49,14 +112,22 @@ export default function Checkout() {
       <Card className="w-full max-w-md space-y-4">
         <h1 className="text-xl font-semibold text-center">Checkout do plano {plan}</h1>
         <form onSubmit={handleSubmit} className="space-y-3">
+          <Input name="cpf" placeholder="CPF" onChange={handleChange} />
+          <Input name="phone" placeholder="Telefone" onChange={handleChange} />
+          <Input name="brand" placeholder="Bandeira" onChange={handleChange} />
           <Input name="number" placeholder="Número do cartão" onChange={handleChange} />
-          <Input name="holder" placeholder="Nome do titular" onChange={handleChange} />
-          <div className="flex gap-2">
-            <Input name="expMonth" placeholder="Mês" onChange={handleChange} />
-            <Input name="expYear" placeholder="Ano" onChange={handleChange} />
-            <Input name="cvv" placeholder="CVV" onChange={handleChange} />
-          </div>
-          <Button type="submit" className="w-full">Pagar</Button>
+          <Input name="cvv" placeholder="CVV" onChange={handleChange} />
+          <Input name="expiration_month" placeholder="Mês de vencimento" onChange={handleChange} />
+          <Input name="expiration_year" placeholder="Ano de vencimento" onChange={handleChange} />
+          <Input name="street" placeholder="Rua" onChange={handleChange} />
+          <Input name="num" placeholder="Número" onChange={handleChange} />
+          <Input name="neighborhood" placeholder="Bairro" onChange={handleChange} />
+          <Input name="zipcode" placeholder="CEP" onChange={handleChange} />
+          <Input name="city" placeholder="Cidade" onChange={handleChange} />
+          <Input name="state" placeholder="Estado" onChange={handleChange} />
+          <Button type="submit" className="w-full" disabled={!checkoutObj}>
+            Pagar
+          </Button>
         </form>
       </Card>
     </div>

--- a/pages/checkoutadmin.tsx
+++ b/pages/checkoutadmin.tsx
@@ -148,6 +148,29 @@ export default function CheckoutAdmin() {
         </form>
       </section>
 
+      <section>
+        <h2 className="font-bold">Atualizar metadados</h2>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            const form = e.currentTarget as any;
+            call('updateSubscriptionMetadata', {
+              id: Number(form.id.value),
+              body: {
+                custom_id: form.customId.value,
+                notification_url: form.url.value
+              }
+            });
+          }}
+          className="space-x-2"
+        >
+          <input name="id" placeholder="Subscription ID" type="number" className="border p-1 w-32" />
+          <input name="customId" placeholder="Custom ID" className="border p-1" />
+          <input name="url" placeholder="Notification URL" className="border p-1 w-64" />
+          <button className="bg-purple-500 text-white px-2 py-1">Atualizar</button>
+        </form>
+      </section>
+
       <pre className="whitespace-pre-wrap bg-gray-100 p-2">{log}</pre>
     </div>
   );

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -9,7 +9,6 @@ import { PLAN_LIMITS } from '../lib/utils';
 
 interface SignUpForm {
   companyName: string;
-  plan: string;
   name: string;
   phone: string;
   email: string;
@@ -19,7 +18,6 @@ interface SignUpForm {
 export default function Register() {
   const [form, setForm] = useState<SignUpForm>({
     companyName: '',
-    plan: 'basic',
     name: '',
     phone: '',
     email: '',
@@ -27,9 +25,7 @@ export default function Register() {
   });
   const router = useRouter();
 
-  const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
-  ) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
   };
 
@@ -44,17 +40,14 @@ export default function Register() {
       return;
     }
     const userId = authData.user.id;
-    const maxEmployees =
-      form.plan === 'basic'
-        ? PLAN_LIMITS.basic
-        : 0;
+    const maxEmployees = PLAN_LIMITS.free;
     const { data: company, error: companyError } = await supabase
       .from('companies')
       .insert({
         name: form.companyName,
         email: form.email,
         phone: form.phone,
-        plan: form.plan,
+        plan: 'free',
         maxemployees: maxEmployees
       })
       .select()
@@ -74,15 +67,7 @@ export default function Register() {
       alert(userError.message);
       return;
     }
-    if (form.plan === 'basic') {
-      router.push('/dashboard');
-    } else {
-      router.push(
-        `/checkout?plan=${form.plan}&companyId=${company.id}&name=${encodeURIComponent(
-          form.name
-        )}&email=${encodeURIComponent(form.email)}`
-      );
-    }
+    router.push('/dashboard');
   };
 
   return (
@@ -93,17 +78,6 @@ export default function Register() {
         </h1>
         <form onSubmit={handleSubmit} className="space-y-3">
           <Input name="companyName" placeholder="Empresa" onChange={handleChange} />
-          <label className="block text-sm">Plano</label>
-          <select
-            name="plan"
-            value={form.plan}
-            onChange={handleChange}
-            className="w-full border rounded p-2"
-          >
-            <option value="basic">Básico - 5 funcionários</option>
-            <option value="pro">Pro - 50 funcionários</option>
-            <option value="enterprise">Enterprise - 500 funcionários</option>
-          </select>
           <Input name="name" placeholder="Seu nome" onChange={handleChange} />
           <Input name="phone" placeholder="Telefone" onChange={handleChange} />
           <Input name="email" placeholder="Email" onChange={handleChange} />

--- a/pages/upgrade.tsx
+++ b/pages/upgrade.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Layout from '../components/Layout';
+import { Button } from '../components/ui/button';
+import { supabase } from '../lib/supabaseClient';
+import { PLAN_LIMITS } from '../lib/utils';
+
+interface Profile {
+  name: string;
+  email: string;
+  companyId: string;
+}
+
+export default function Upgrade() {
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    const load = async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) {
+        router.replace('/login');
+        return;
+      }
+      const { data } = await supabase
+        .from('users')
+        .select('name,email,company_id')
+        .eq('id', user.id)
+        .single();
+      setProfile({
+        name: data?.name ?? '',
+        email: data?.email ?? '',
+        companyId: data?.company_id ?? ''
+      });
+    };
+    load();
+  }, [router]);
+
+  if (!profile) return <p>Carregando...</p>;
+
+  const plans = [
+    { id: 'pro', label: 'Pro', limit: PLAN_LIMITS.pro },
+    { id: 'enterprise', label: 'Enterprise', limit: PLAN_LIMITS.enterprise },
+  ];
+
+  const gotoCheckout = (planId: string) => {
+    router.push(
+      `/checkout?plan=${planId}&companyId=${profile.companyId}&name=${encodeURIComponent(
+        profile.name
+      )}&email=${encodeURIComponent(profile.email)}`
+    );
+  };
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-bold mb-6">Upgrade de plano</h1>
+      <div className="grid md:grid-cols-2 gap-4">
+        {plans.map((p) => (
+          <div key={p.id} className="border rounded p-4 flex flex-col">
+            <h2 className="font-semibold text-lg mb-2">{p.label}</h2>
+            <p className="mb-4">Até {p.limit} funcionários</p>
+            <Button onClick={() => gotoCheckout(p.id)}>Selecionar</Button>
+          </div>
+        ))}
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- default new signups to a free plan with a 5 employee cap
- add account dropdown with upgrade link
- create an upgrade page that redirects to checkout for selected plan
- fix PHP subscription helper output handling

## Testing
- `npm test`
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_689885477d20832d94a7bbdff76d37fc