### PR TITLE
Add company user management interface

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { LayoutDashboard, Users, User as UserIcon } from 'lucide-react';
+import { LayoutDashboard, Users, User as UserIcon, UserCog } from 'lucide-react';
 import { cn } from '../lib/utils';
 import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
@@ -27,6 +27,7 @@ export default function Sidebar() {
   const links = [
     { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { href: '/employees', label: 'Funcionários', icon: Users },
+    { href: '/users', label: 'Usuários & Permissões', icon: UserCog },
   ];
 
   return (

--- a/pages/api/company-users.ts
+++ b/pages/api/company-users.ts
@@ -1,0 +1,105 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  switch (req.method) {
+    case 'POST': {
+      const { name, email, password, phone, position, company_id } = req.body;
+      if (!name || !email || !password || !company_id)
+        return res.status(400).json({ error: 'Missing fields' });
+
+      const { data, error } = await supabaseAdmin.auth.admin.createUser({
+        email,
+        password,
+        phone: phone || undefined,
+        email_confirm: true,
+      });
+      if (error || !data.user)
+        return res.status(400).json({ error: error?.message });
+
+      const { error: linkError } = await supabaseAdmin
+        .from('companies_users')
+        .insert({
+          company_id,
+          user_id: data.user.id,
+          name,
+          email,
+          phone: phone || null,
+          position,
+        });
+      if (linkError)
+        return res.status(400).json({ error: linkError.message });
+
+      return res.status(200).json({ user_id: data.user.id });
+    }
+
+    case 'GET': {
+      const { company_id } = req.query;
+      const { data, error } = await supabaseAdmin
+        .from('companies_users')
+        .select('user_id, name, email, phone, position')
+        .eq('company_id', company_id as string);
+      if (error) return res.status(400).json({ error: error.message });
+      return res.status(200).json(data);
+    }
+
+    case 'PUT': {
+      const { user_id, name, email, phone, position, password } = req.body;
+      const authUpdates: { email?: string; password?: string; phone?: string } = {};
+      if (email) authUpdates.email = email;
+      if (password) authUpdates.password = password;
+      if (phone) authUpdates.phone = phone;
+
+      if (Object.keys(authUpdates).length) {
+        const { error: authError } = await supabaseAdmin.auth.admin.updateUserById(
+          user_id,
+          authUpdates
+        );
+        if (authError) return res.status(400).json({ error: authError.message });
+      }
+
+      const rowUpdates: {
+        name?: string;
+        email?: string;
+        phone?: string | null;
+        position?: string | null;
+      } = {};
+      if (name) rowUpdates.name = name;
+      if (email) rowUpdates.email = email;
+      if (phone) rowUpdates.phone = phone;
+      if (position) rowUpdates.position = position;
+
+      if (Object.keys(rowUpdates).length) {
+        const { error: linkError } = await supabaseAdmin
+          .from('companies_users')
+          .update(rowUpdates)
+          .eq('user_id', user_id);
+        if (linkError) return res.status(400).json({ error: linkError.message });
+      }
+
+      return res.status(200).json({ ok: true });
+    }
+
+    case 'DELETE': {
+      const { id, company_id } = req.query;
+      await supabaseAdmin
+        .from('companies_users')
+        .delete()
+        .eq('company_id', company_id as string)
+        .eq('user_id', id as string);
+      await supabaseAdmin.auth.admin.deleteUser(id as string);
+
+      return res.status(200).json({ ok: true });
+    }
+
+    default:
+      return res.status(405).end();
+  }
+}

--- a/pages/users/index.tsx
+++ b/pages/users/index.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useState } from 'react';
+import Layout from '../../components/Layout';
+import { supabase } from '../../lib/supabaseClient';
+import { Button } from '../../components/ui/button';
+
+interface CompanyUser {
+  user_id: string;
+  name: string;
+  email: string;
+  phone: string | null;
+  position: string | null;
+}
+
+export default function CompanyUsersPage() {
+  const [companyId, setCompanyId] = useState<string>('');
+  const [users, setUsers] = useState<CompanyUser[]>([]);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [phone, setPhone] = useState('');
+  const [position, setPosition] = useState('');
+  const [positions, setPositions] = useState<string[]>([]);
+  const [error, setError] = useState<string>('');
+  const [loadingCompany, setLoadingCompany] = useState(true);
+
+  const loadUsers = async (cid: string) => {
+    const res = await fetch(`/api/company-users?company_id=${cid}`);
+    if (res.ok) {
+      const data = await res.json();
+      setUsers(data);
+    }
+  };
+
+  const loadPositions = async (cid: string) => {
+    const { data } = await supabase
+      .from('employees')
+      .select('position')
+      .eq('company_id', cid)
+      .not('position', 'is', null);
+    if (data) {
+      const unique = Array.from(new Set(data.map((e: any) => e.position)));
+      setPositions(unique as string[]);
+    }
+  };
+
+  useEffect(() => {
+    const init = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) {
+        setLoadingCompany(false);
+        return;
+      }
+      const { data } = await supabase
+        .from('companies_users')
+        .select('company_id')
+        .eq('user_id', session.user.id)
+        .single();
+      if (data) {
+        setCompanyId(data.company_id);
+        loadUsers(data.company_id);
+        loadPositions(data.company_id);
+      } else {
+        const { data: fallback } = await supabase
+          .from('users')
+          .select('company_id')
+          .eq('id', session.user.id)
+          .single();
+        if (fallback) {
+          setCompanyId(fallback.company_id);
+          loadUsers(fallback.company_id);
+          loadPositions(fallback.company_id);
+        }
+      }
+      setLoadingCompany(false);
+    };
+    init();
+  }, []);
+
+  const addUser = async () => {
+    setError('');
+    if (!companyId) {
+      setError('Empresa não encontrada');
+      return;
+    }
+    const res = await fetch('/api/company-users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name,
+        email,
+        password,
+        phone,
+        position: position || null,
+        company_id: companyId,
+      }),
+    });
+    if (res.ok) {
+      setName('');
+      setEmail('');
+      setPassword('');
+      setPhone('');
+      setPosition('');
+      loadUsers(companyId);
+    } else {
+      const { error: err } = await res.json();
+      setError(err || 'Erro ao adicionar usuário');
+    }
+  };
+
+  const updateUser = async (u: CompanyUser) => {
+    const newName = prompt('Nome:', u.name);
+    const newEmail = prompt('Email:', u.email);
+    const newPhone = prompt('Telefone:', u.phone || '');
+    const newPosition = prompt('Cargo:', u.position || '');
+    const newPassword = prompt('Nova senha (deixe vazio para manter):');
+    await fetch('/api/company-users', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        user_id: u.user_id,
+        name: newName || undefined,
+        email: newEmail || undefined,
+        phone: newPhone || undefined,
+        position: newPosition || undefined,
+        password: newPassword || undefined,
+      }),
+    });
+    loadUsers(companyId);
+  };
+
+  const removeUser = async (u: CompanyUser) => {
+    if (!confirm('Excluir este usuário?')) return;
+    await fetch(`/api/company-users?id=${u.user_id}&company_id=${companyId}`, { method: 'DELETE' });
+    loadUsers(companyId);
+  };
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-bold mb-4">Usuários & Permissões</h1>
+      <div className="mb-6 flex gap-2 flex-wrap">
+        <input
+          type="text"
+          placeholder="Nome"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="border p-2 rounded"
+        />
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="border p-2 rounded"
+        />
+        <input
+          type="password"
+          placeholder="Senha"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2 rounded"
+        />
+        <input
+          type="text"
+          placeholder="Telefone"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          className="border p-2 rounded"
+        />
+        <select
+          value={position}
+          onChange={(e) => setPosition(e.target.value)}
+          className="border p-2 rounded"
+        >
+          <option value="">Selecione o cargo</option>
+          {positions.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+        <Button
+          onClick={addUser}
+          disabled={
+            loadingCompany || !name || !email || !password
+          }
+        >
+          Adicionar
+        </Button>
+      </div>
+      {error && <p className="text-red-500 mb-4">{error}</p>}
+      <table className="w-full text-left border-collapse">
+        <thead>
+          <tr>
+            <th className="p-2 border-b">Nome</th>
+            <th className="p-2 border-b">Email</th>
+            <th className="p-2 border-b">Telefone</th>
+            <th className="p-2 border-b">Cargo</th>
+            <th className="p-2 border-b">Ações</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((u) => (
+            <tr key={u.user_id}>
+              <td className="p-2 border-b">{u.name}</td>
+              <td className="p-2 border-b">{u.email}</td>
+              <td className="p-2 border-b">{u.phone || '-'}</td>
+              <td className="p-2 border-b">{u.position || '-'}</td>
+              <td className="p-2 border-b space-x-2">
+                <Button variant="outline" onClick={() => updateUser(u)}>
+                  Editar
+                </Button>
+                <Button variant="outline" onClick={() => removeUser(u)}>
+                  Excluir
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </Layout>
+  );
+}
+

--- a/supabase.sql
+++ b/supabase.sql
@@ -4,6 +4,7 @@ create table public.companies (
   email text,
   phone text,
   plan text,
+  plan_id uuid references public.plans(id),
   maxemployees integer
 );
 
@@ -12,7 +13,8 @@ create table public.users (
   name text,
   phone text,
   email text,
-  company_id uuid references public.companies(id)
+  company_id uuid references public.companies(id),
+  is_admin boolean default false
 );
 
 create table public.employees (
@@ -79,3 +81,39 @@ create table public.subscriptions (
   status text default 'pending',
   created_at timestamptz default now()
 );
+
+create table public.companies_users (
+  company_id uuid not null,
+  user_id uuid not null,
+  name text not null,
+  email text not null,
+  phone text,
+  position text,
+  role public.company_user_role not null default 'viewer'::company_user_role,
+  scopes jsonb not null default '{}'::jsonb,
+  allowed_fields jsonb not null default '[]'::jsonb,
+  created_at timestamp with time zone not null default now(),
+  constraint companies_users_pkey primary key (company_id, user_id),
+  constraint companies_users_company_id_fkey foreign key (company_id) references companies (id) on delete cascade,
+  constraint companies_users_user_id_fkey foreign key (user_id) references auth.users (id) on delete cascade,
+  constraint companies_users_allowed_fields_is_array check ((jsonb_typeof(allowed_fields) = 'array'::text)),
+  constraint companies_users_scopes_is_object check ((jsonb_typeof(scopes) = 'object'::text))
+);
+
+create index if not exists companies_users_company_id_idx on public.companies_users using btree (company_id);
+create index if not exists companies_users_user_id_idx on public.companies_users using btree (user_id);
+
+create trigger companies_users_validate_scopes before insert or update on companies_users for each row execute function trg_companies_users_validate_scopes ();
+
+-- Snippet para atualizar bancos existentes
+-- alter table if exists public.users add column if not exists is_admin boolean default false;
+-- alter table if exists public.companies add column if not exists plan_id uuid;
+-- alter table public.companies add constraint companies_plan_id_fkey foreign key (plan_id) references public.plans(id);
+-- atualiza plan_id de empresas existentes com base no campo plan
+-- update public.companies c set plan_id = p.id from public.plans p where c.plan = p.name;
+-- limpa plan_id quando o plano informado não existe
+-- update public.companies set plan_id = null where plan is not null and plan not in (select name from public.plans);
+-- alter table if exists public.companies_users add column if not exists name text;
+-- alter table if exists public.companies_users add column if not exists email text;
+-- alter table if exists public.companies_users add column if not exists phone text;
+-- alter table if exists public.companies_users add column if not exists position text;


### PR DESCRIPTION
## Summary
- add name/email/phone/position fields to companies_users table and provide migration snippet
- expose these fields in the API for creating, updating and listing company users
- extend Users & Permissions page to capture and display employee details and available positions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f37a86218832da3ce2deb451419c7