### PR TITLE
Add company user management interface

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { LayoutDashboard, Users, User as UserIcon } from 'lucide-react';
+import { LayoutDashboard, Users, User as UserIcon, UserCog } from 'lucide-react';
 import { cn } from '../lib/utils';
 import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
@@ -27,6 +27,7 @@ export default function Sidebar() {
   const links = [
     { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { href: '/employees', label: 'Funcionários', icon: Users },
+    { href: '/users', label: 'Usuários & Permissões', icon: UserCog },
   ];
 
   return (

--- a/pages/api/company-users.ts
+++ b/pages/api/company-users.ts
@@ -1,0 +1,111 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  switch (req.method) {
+    case 'POST': {
+      const { name, email, password, phone, position, company_id, scopes, allowed_fields } = req.body;
+      if (!name || !email || !password || !company_id)
+        return res.status(400).json({ error: 'Missing fields' });
+
+      const { data, error } = await supabaseAdmin.auth.admin.createUser({
+        email,
+        password,
+        phone: phone || undefined,
+        email_confirm: true,
+      });
+      if (error || !data.user)
+        return res.status(400).json({ error: error?.message });
+
+      const { error: linkError } = await supabaseAdmin
+        .from('companies_users')
+        .insert({
+          company_id,
+          user_id: data.user.id,
+          name,
+          email,
+          phone: phone || null,
+          position,
+          scopes: scopes || {},
+          allowed_fields: allowed_fields || [],
+        });
+      if (linkError)
+        return res.status(400).json({ error: linkError.message });
+
+      return res.status(200).json({ user_id: data.user.id });
+    }
+
+    case 'GET': {
+      const { company_id } = req.query;
+      const { data, error } = await supabaseAdmin
+        .from('companies_users')
+        .select('user_id, name, email, phone, position, scopes, allowed_fields')
+        .eq('company_id', company_id as string);
+      if (error) return res.status(400).json({ error: error.message });
+      return res.status(200).json(data);
+    }
+
+    case 'PUT': {
+      const { user_id, name, email, phone, position, password, scopes, allowed_fields } = req.body;
+      const authUpdates: { email?: string; password?: string; phone?: string } = {};
+      if (email) authUpdates.email = email;
+      if (password) authUpdates.password = password;
+      if (phone) authUpdates.phone = phone;
+
+      if (Object.keys(authUpdates).length) {
+        const { error: authError } = await supabaseAdmin.auth.admin.updateUserById(
+          user_id,
+          authUpdates
+        );
+        if (authError) return res.status(400).json({ error: authError.message });
+      }
+
+      const rowUpdates: {
+        name?: string;
+        email?: string;
+        phone?: string | null;
+        position?: string | null;
+        scopes?: any;
+        allowed_fields?: any;
+      } = {};
+      if (name) rowUpdates.name = name;
+      if (email) rowUpdates.email = email;
+      if (phone) rowUpdates.phone = phone;
+      if (position) rowUpdates.position = position;
+      if (scopes) rowUpdates.scopes = scopes;
+      if (allowed_fields) rowUpdates.allowed_fields = allowed_fields;
+
+      if (Object.keys(rowUpdates).length) {
+        const { error: linkError } = await supabaseAdmin
+          .from('companies_users')
+          .update(rowUpdates)
+          .eq('user_id', user_id);
+        if (linkError) return res.status(400).json({ error: linkError.message });
+      }
+
+      return res.status(200).json({ ok: true });
+    }
+
+    case 'DELETE': {
+      const { id, company_id } = req.query;
+      await supabaseAdmin
+        .from('companies_users')
+        .delete()
+        .eq('company_id', company_id as string)
+        .eq('user_id', id as string);
+      await supabaseAdmin.auth.admin.deleteUser(id as string);
+
+      return res.status(200).json({ ok: true });
+    }
+
+    default:
+      return res.status(405).end();
+  }
+}

--- a/pages/users/index.tsx
+++ b/pages/users/index.tsx
@@ -1,0 +1,287 @@
+import { useEffect, useState } from 'react';
+import Layout from '../../components/Layout';
+import { supabase } from '../../lib/supabaseClient';
+import { Button } from '../../components/ui/button';
+
+interface CompanyUser {
+  user_id: string;
+  name: string;
+  email: string;
+  phone: string | null;
+  position: string | null;
+  scopes?: Record<string, any>;
+  allowed_fields?: string[];
+}
+
+export default function CompanyUsersPage() {
+  const [companyId, setCompanyId] = useState<string>('');
+  const [users, setUsers] = useState<CompanyUser[]>([]);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [phone, setPhone] = useState('');
+  const [position, setPosition] = useState('');
+  const [positions, setPositions] = useState<string[]>([]);
+  const [error, setError] = useState<string>('');
+  const [loadingCompany, setLoadingCompany] = useState(true);
+  const [accessUser, setAccessUser] = useState<CompanyUser | null>(null);
+  const [scopesText, setScopesText] = useState('');
+  const [allowedText, setAllowedText] = useState('');
+
+  const loadUsers = async (cid: string) => {
+    const res = await fetch(`/api/company-users?company_id=${cid}`);
+    if (res.ok) {
+      const data = await res.json();
+      setUsers(data);
+    }
+  };
+
+  const loadPositions = async (cid: string) => {
+    const { data } = await supabase
+      .from('employees')
+      .select('position')
+      .eq('company_id', cid)
+      .not('position', 'is', null);
+    if (data) {
+      const unique = Array.from(new Set(data.map((e: any) => e.position)));
+      setPositions(unique as string[]);
+    }
+  };
+
+  useEffect(() => {
+    const init = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) {
+        setLoadingCompany(false);
+        return;
+      }
+      const { data } = await supabase
+        .from('companies_users')
+        .select('company_id')
+        .eq('user_id', session.user.id)
+        .single();
+      if (data) {
+        setCompanyId(data.company_id);
+        loadUsers(data.company_id);
+        loadPositions(data.company_id);
+      } else {
+        const { data: fallback } = await supabase
+          .from('users')
+          .select('company_id')
+          .eq('id', session.user.id)
+          .single();
+        if (fallback) {
+          setCompanyId(fallback.company_id);
+          loadUsers(fallback.company_id);
+          loadPositions(fallback.company_id);
+        }
+      }
+      setLoadingCompany(false);
+    };
+    init();
+  }, []);
+
+  const addUser = async () => {
+    setError('');
+    if (!companyId) {
+      setError('Empresa não encontrada');
+      return;
+    }
+    const res = await fetch('/api/company-users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name,
+        email,
+        password,
+        phone,
+        position: position || null,
+        company_id: companyId,
+      }),
+    });
+    if (res.ok) {
+      setName('');
+      setEmail('');
+      setPassword('');
+      setPhone('');
+      setPosition('');
+      loadUsers(companyId);
+    } else {
+      const { error: err } = await res.json();
+      setError(err || 'Erro ao adicionar usuário');
+    }
+  };
+
+  const updateUser = async (u: CompanyUser) => {
+    const newName = prompt('Nome:', u.name);
+    const newEmail = prompt('Email:', u.email);
+    const newPhone = prompt('Telefone:', u.phone || '');
+    const newPosition = prompt('Cargo:', u.position || '');
+    const newPassword = prompt('Nova senha (deixe vazio para manter):');
+    await fetch('/api/company-users', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        user_id: u.user_id,
+        name: newName || undefined,
+        email: newEmail || undefined,
+        phone: newPhone || undefined,
+        position: newPosition || undefined,
+        password: newPassword || undefined,
+      }),
+    });
+    loadUsers(companyId);
+  };
+
+  const removeUser = async (u: CompanyUser) => {
+    if (!confirm('Excluir este usuário?')) return;
+    await fetch(`/api/company-users?id=${u.user_id}&company_id=${companyId}`, { method: 'DELETE' });
+    loadUsers(companyId);
+  };
+
+  const openAccessModal = (u: CompanyUser) => {
+    setAccessUser(u);
+    setScopesText(JSON.stringify(u.scopes || {}, null, 2));
+    setAllowedText((u.allowed_fields || []).join(','));
+  };
+
+  const saveAccess = async () => {
+    if (!accessUser) return;
+    try {
+      const scopes = scopesText ? JSON.parse(scopesText) : {};
+      const allowed_fields = allowedText
+        ? allowedText.split(',').map((f) => f.trim()).filter(Boolean)
+        : [];
+      await fetch('/api/company-users', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          user_id: accessUser.user_id,
+          scopes,
+          allowed_fields,
+        }),
+      });
+      setAccessUser(null);
+      loadUsers(companyId);
+    } catch (e) {
+      alert('JSON de scopes inválido');
+    }
+  };
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-bold mb-4">Usuários & Permissões</h1>
+      <div className="mb-6 flex gap-2 flex-wrap">
+        <input
+          type="text"
+          placeholder="Nome"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="border p-2 rounded"
+        />
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="border p-2 rounded"
+        />
+        <input
+          type="password"
+          placeholder="Senha"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2 rounded"
+        />
+        <input
+          type="text"
+          placeholder="Telefone"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          className="border p-2 rounded"
+        />
+        <select
+          value={position}
+          onChange={(e) => setPosition(e.target.value)}
+          className="border p-2 rounded"
+        >
+          <option value="">Selecione o cargo</option>
+          {positions.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+        <Button
+          onClick={addUser}
+          disabled={
+            loadingCompany || !name || !email || !password
+          }
+        >
+          Adicionar
+        </Button>
+      </div>
+      {error && <p className="text-red-500 mb-4">{error}</p>}
+      <table className="w-full text-left border-collapse">
+        <thead>
+          <tr>
+            <th className="p-2 border-b">Nome</th>
+            <th className="p-2 border-b">Email</th>
+            <th className="p-2 border-b">Telefone</th>
+            <th className="p-2 border-b">Cargo</th>
+            <th className="p-2 border-b">Ações</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((u) => (
+            <tr key={u.user_id}>
+              <td className="p-2 border-b">{u.name}</td>
+              <td className="p-2 border-b">{u.email}</td>
+              <td className="p-2 border-b">{u.phone || '-'}</td>
+              <td className="p-2 border-b">{u.position || '-'}</td>
+              <td className="p-2 border-b space-x-2">
+                <Button variant="outline" onClick={() => updateUser(u)}>
+                  Editar
+                </Button>
+                <Button variant="outline" onClick={() => openAccessModal(u)}>
+                  Configurar acesso
+                </Button>
+                <Button variant="outline" onClick={() => removeUser(u)}>
+                  Excluir
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {accessUser && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+          <div className="bg-white p-4 rounded w-full max-w-lg space-y-2">
+            <h2 className="text-xl font-semibold mb-2">Configurar acesso</h2>
+            <textarea
+              className="w-full border p-2 rounded h-40"
+              value={scopesText}
+              onChange={(e) => setScopesText(e.target.value)}
+              placeholder="scopes em JSON"
+            />
+            <input
+              className="w-full border p-2 rounded"
+              value={allowedText}
+              onChange={(e) => setAllowedText(e.target.value)}
+              placeholder="allowed fields separados por vírgula"
+            />
+            <div className="flex justify-end gap-2 pt-2">
+              <Button variant="outline" onClick={() => setAccessUser(null)}>
+                Cancelar
+              </Button>
+              <Button onClick={saveAccess}>Salvar</Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </Layout>
+  );
+}
+

--- a/supabase.sql
+++ b/supabase.sql
@@ -4,6 +4,7 @@ create table public.companies (
   email text,
   phone text,
   plan text,
+  plan_id uuid references public.plans(id),
   maxemployees integer
 );
 
@@ -12,7 +13,8 @@ create table public.users (
   name text,
   phone text,
   email text,
-  company_id uuid references public.companies(id)
+  company_id uuid references public.companies(id),
+  is_admin boolean default false
 );
 
 create table public.employees (
@@ -79,3 +81,174 @@ create table public.subscriptions (
   status text default 'pending',
   created_at timestamptz default now()
 );
+
+create table public.companies_users (
+  company_id uuid not null,
+  user_id uuid not null,
+  name text not null,
+  email text not null,
+  phone text,
+  position text,
+  role public.company_user_role not null default 'viewer'::company_user_role,
+  scopes jsonb not null default '{}'::jsonb,
+  allowed_fields jsonb not null default '[]'::jsonb,
+  created_at timestamp with time zone not null default now(),
+  constraint companies_users_pkey primary key (company_id, user_id),
+  constraint companies_users_company_id_fkey foreign key (company_id) references companies (id) on delete cascade,
+  constraint companies_users_user_id_fkey foreign key (user_id) references auth.users (id) on delete cascade,
+  constraint companies_users_allowed_fields_is_array check ((jsonb_typeof(allowed_fields) = 'array'::text)),
+  constraint companies_users_scopes_is_object check ((jsonb_typeof(scopes) = 'object'::text))
+);
+
+create index if not exists companies_users_company_id_idx on public.companies_users using btree (company_id);
+create index if not exists companies_users_user_id_idx on public.companies_users using btree (user_id);
+
+create trigger companies_users_validate_scopes before insert or update on companies_users for each row execute function trg_companies_users_validate_scopes ();
+
+-- Snippet para atualizar bancos existentes
+-- alter table if exists public.users add column if not exists is_admin boolean default false;
+-- alter table if exists public.companies add column if not exists plan_id uuid;
+-- alter table public.companies add constraint companies_plan_id_fkey foreign key (plan_id) references public.plans(id);
+-- atualiza plan_id de empresas existentes com base no campo plan
+-- update public.companies c set plan_id = p.id from public.plans p where c.plan = p.name;
+-- limpa plan_id quando o plano informado não existe
+-- update public.companies set plan_id = null where plan is not null and plan not in (select name from public.plans);
+-- alter table if exists public.companies_users add column if not exists name text;
+-- alter table if exists public.companies_users add column if not exists email text;
+-- alter table if exists public.companies_users add column if not exists phone text;
+-- alter table if exists public.companies_users add column if not exists position text;
+
+-- Helpers de acesso e planos
+create or replace function app_current_company_id() returns uuid as $$
+  select company_id from companies_users where user_id = auth.uid() limit 1;
+$$ language sql stable;
+
+create or replace function app_is_superadmin() returns boolean as $$
+  select coalesce(is_admin, false) from public.users where id = auth.uid();
+$$ language sql stable;
+
+create or replace function app_effective_features(company uuid) returns jsonb as $$
+  select coalesce(p.features, '{}'::jsonb) || coalesce(c.plan_overrides, '{}'::jsonb)
+  from public.companies c
+  left join public.plans p on c.plan_id = p.id
+  where c.id = company;
+$$ language sql stable;
+
+create or replace function app_feature_enabled(company uuid, module text) returns boolean as $$
+  select coalesce((app_effective_features(company)->>module)::boolean, false);
+$$ language sql stable;
+
+create or replace function app_allowed_fields(company uuid) returns text[] as $$
+  select coalesce(array(select jsonb_array_elements_text(cu.allowed_fields)), array[]::text[])
+  from public.companies_users cu
+  where cu.company_id = company and cu.user_id = auth.uid();
+$$ language sql stable;
+
+create or replace function app_has_scope(company uuid, module text, action text) returns boolean as $$
+  select app_is_superadmin() or (
+    app_feature_enabled(company, module) and
+    coalesce((select (cu.scopes -> module ->> action)::boolean
+              from public.companies_users cu
+              where cu.company_id = company and cu.user_id = auth.uid()), false)
+  );
+$$ language sql stable;
+
+-- RLS para employees
+alter table public.employees enable row level security;
+
+create policy employees_tenant_policy on public.employees
+  using (company_id = app_current_company_id() or app_is_superadmin())
+  with check (company_id = app_current_company_id() or app_is_superadmin());
+
+-- Listagem mascarada de funcionários
+create or replace function app_list_employees_masked(company uuid)
+returns setof public.employees as $$
+  select
+    id,
+    company_id,
+    case when 'name' = any(app_allowed_fields(company)) then name else null end as name,
+    case when 'email' = any(app_allowed_fields(company)) then email else null end as email,
+    case when 'phone' = any(app_allowed_fields(company)) then phone else null end as phone,
+    case when 'position' = any(app_allowed_fields(company)) then position else null end as position,
+    case when 'salary' = any(app_allowed_fields(company)) then salary else null end as salary,
+    case when 'cpf' = any(app_allowed_fields(company)) then cpf else null end as cpf,
+    street,
+    city,
+    state,
+    zip,
+    department,
+    hire_date,
+    termination_date,
+    termination_reason,
+    status,
+    gender,
+    emergency_contact_name,
+    emergency_contact_phone,
+    emergency_contact_relation,
+    resume_url,
+    comments,
+    custom_fields,
+    created_at
+  from public.employees
+  where company_id = company;
+$$ language sql stable;
+
+-- RPCs que reforçam permissões
+create or replace function app_employee_dismiss(emp_id uuid, reason text)
+returns void as $$
+declare company uuid;
+begin
+  select company_id into company from public.employees where id = emp_id;
+  if not app_has_scope(company, 'employees', 'dismiss') then
+    raise exception 'permission denied';
+  end if;
+  update public.employees
+    set status = 'dismissed', termination_reason = reason, termination_date = now()
+    where id = emp_id;
+end;
+$$ language plpgsql security definer;
+
+create or replace function app_employee_toggle_status(emp_id uuid, to_status text)
+returns void as $$
+declare company uuid;
+begin
+  select company_id into company from public.employees where id = emp_id;
+  if to_status = 'active' then
+    if not app_has_scope(company, 'employees', 'activate') then
+      raise exception 'permission denied';
+    end if;
+  else
+    if not app_has_scope(company, 'employees', 'deactivate') then
+      raise exception 'permission denied';
+    end if;
+  end if;
+  update public.employees set status = to_status where id = emp_id;
+end;
+$$ language plpgsql security definer;
+
+create or replace function app_employee_update_salary(emp_id uuid, new_salary numeric)
+returns void as $$
+declare company uuid;
+begin
+  select company_id into company from public.employees where id = emp_id;
+  if not app_has_scope(company, 'employees', 'update_salary') then
+    raise exception 'permission denied';
+  end if;
+  update public.employees set salary = new_salary where id = emp_id;
+end;
+$$ language plpgsql security definer;
+
+create or replace function app_employees_export(company uuid)
+returns setof public.employees as $$
+begin
+  if not app_has_scope(company, 'employees', 'export') then
+    raise exception 'permission denied';
+  end if;
+  return query select * from app_list_employees_masked(company);
+end;
+$$ language plpgsql security definer;
+
+-- Snippet para aplicar RLS em bancos existentes
+-- alter table if exists public.employees enable row level security;
+-- drop policy if exists employees_tenant_policy on public.employees;
+-- create policy employees_tenant_policy on public.employees using (company_id = app_current_company_id() or app_is_superadmin()) with check (company_id = app_current_company_id() or app_is_superadmin());


### PR DESCRIPTION
## Summary
- implement SQL helpers for plan features, per-user scopes and allowed fields, and enforce RLS with tenant policies
- expose scopes and allowed_fields in the company-users API and allow updating them
- add "Configurar acesso" modal on Users & Permissions page to edit scopes and visible fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f37a86218832da3ce2deb451419c7