### PR TITLE
Add company user management interface

### DIFF
--- a/ORIENTACOES.txt
+++ b/ORIENTACOES.txt
@@ -1,0 +1,5 @@
+- Contas principais (registradas em public.users) possuem todos os módulos, ações e campos liberados.
+- Usuários vinculados via companies_users precisam ter scopes e allowed_fields definidos.
+- Ao adicionar novos módulos ou campos de funcionário, atualize SCOPE_DEFINITIONS e EMPLOYEE_FIELD_OPTIONS.
+- Funções app_has_scope e app_allowed_fields fazem fallback para public.users quando não existe registro em companies_users.
+- A página de administração possui abas para configurar planos e uma seção de debug que exibe dados da empresa, módulos habilitados e escopos do usuário.

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { LayoutDashboard, Users, User as UserIcon } from 'lucide-react';
+import { LayoutDashboard, Users, User as UserIcon, UserCog, Settings } from 'lucide-react';
 import { cn } from '../lib/utils';
 import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
@@ -8,7 +8,7 @@ import { supabase } from '../lib/supabaseClient';
 export default function Sidebar() {
   const router = useRouter();
   const [menuOpen, setMenuOpen] = useState(false);
-  const [profile, setProfile] = useState<{ name: string; email: string } | null>(null);
+  const [profile, setProfile] = useState<{ name: string; email: string; is_admin?: boolean } | null>(null);
 
   useEffect(() => {
     supabase.auth.getUser().then(async ({ data }) => {
@@ -16,7 +16,7 @@ export default function Sidebar() {
       if (user) {
         const { data: profileData } = await supabase
           .from('users')
-          .select('name,email')
+          .select('name,email,is_admin')
           .eq('id', user.id)
           .single();
         if (profileData) setProfile(profileData);
@@ -27,7 +27,11 @@ export default function Sidebar() {
   const links = [
     { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { href: '/employees', label: 'Funcionários', icon: Users },
+    { href: '/users', label: 'Usuários & Permissões', icon: UserCog },
   ];
+  if (profile?.is_admin) {
+    links.push({ href: '/admin', label: 'Admin', icon: Settings });
+  }
 
   return (
     <aside className="w-64 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 min-h-screen p-6 flex flex-col">

--- a/lib/access.ts
+++ b/lib/access.ts
@@ -1,0 +1,39 @@
+export const SCOPE_DEFINITIONS: Record<string, Record<string, string>> = {
+  employees: {
+    read: 'Listar funcionários',
+    create: 'Criar funcionário',
+    update: 'Editar funcionário',
+    update_salary: 'Atualizar salário',
+    dismiss: 'Desligar funcionário',
+    activate: 'Ativar funcionário',
+    deactivate: 'Inativar funcionário',
+    delete: 'Excluir funcionário',
+    export: 'Exportar funcionários',
+  },
+  metrics: {
+    read: 'Ver métricas',
+  },
+  reports: {
+    read: 'Ver relatórios',
+    export: 'Exportar relatórios',
+  },
+};
+
+export const EMPLOYEE_FIELD_OPTIONS: Record<string, string> = {
+  name: 'Nome',
+  email: 'E-mail',
+  phone: 'Telefone',
+  position: 'Cargo',
+  salary: 'Salário',
+  cpf: 'CPF/CNPJ',
+};
+
+export type Scopes = Record<string, Record<string, boolean>>;
+
+export function hasScope(
+  scopes: Scopes | undefined,
+  module: string,
+  action: string
+): boolean {
+  return Boolean(scopes?.[module]?.[action]);
+}

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../../lib/supabaseClient';
+
+const MODULES = ['employees', 'metrics', 'reports'] as const;
+
+interface Plan {
+  id: string;
+  name: string;
+  features_json: string[] | null;
+}
+
+interface DebugInfo {
+  companyId: string;
+  plan: string | null;
+  plan_id: string | null;
+  plan_features: any;
+  plan_overrides: any;
+  effective_features: any;
+  user_scopes: any;
+  allowed_fields: any;
+  modules: Record<string, boolean>;
+  errors: Record<string, any>;
+  trace?: any[];
+}
+
+export default function AdminPage() {
+  const [tab, setTab] = useState<'plans' | 'debug'>('plans');
+
+  // Plan management state
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [loadingPlans, setLoadingPlans] = useState(true);
+  const [planError, setPlanError] = useState<string | null>(null);
+
+  // Debug state
+  const [debug, setDebug] = useState<DebugInfo | null>(null);
+  const [loadingDebug, setLoadingDebug] = useState(true);
+
+  useEffect(() => {
+    async function loadPlans() {
+      const { data: sess } = await supabase.auth.getSession();
+      const token = sess.session?.access_token;
+      if (!token) {
+        setPlanError('unauthenticated');
+        setLoadingPlans(false);
+        return;
+      }
+      const res = await fetch('/api/admin/billing/action', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ action: 'plans_list' }),
+      });
+      const json = await res.json();
+      if (json.ok) setPlans(json.plans as Plan[]);
+      else setPlanError(json.error || 'Erro ao carregar');
+      setLoadingPlans(false);
+    }
+    loadPlans();
+  }, []);
+
+  function toggle(planId: string, feature: string) {
+    setPlans((prev) =>
+      prev.map((p) => {
+        if (p.id !== planId) return p;
+        const arr = Array.isArray(p.features_json) ? [...p.features_json] : [];
+        const idx = arr.indexOf(feature);
+        if (idx >= 0) arr.splice(idx, 1);
+        else arr.push(feature);
+        return { ...p, features_json: arr };
+      })
+    );
+  }
+
+  async function save(plan: Plan) {
+    const { data: sess } = await supabase.auth.getSession();
+    const token = sess.session?.access_token;
+    if (!token) return;
+    await fetch('/api/admin/billing/action', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        action: 'plans_update',
+        id: plan.id,
+        patch: { features_json: plan.features_json },
+      }),
+    });
+  }
+
+  useEffect(() => {
+    async function loadDebug() {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      const token = session?.access_token;
+      if (!token) {
+        setLoadingDebug(false);
+        return;
+      }
+      const res = await fetch('/api/admin/debug', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const json = await res.json();
+      setDebug(json);
+      setLoadingDebug(false);
+    }
+    loadDebug();
+  }, []);
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold">Administração</h1>
+      <div className="flex gap-4 border-b mb-4">
+        <button
+          onClick={() => setTab('plans')}
+          className={`pb-2 ${
+            tab === 'plans'
+              ? 'border-b-2 border-brand font-medium'
+              : 'text-gray-500'
+          }`}
+        >
+          Planos
+        </button>
+        <button
+          onClick={() => setTab('debug')}
+          className={`pb-2 ${
+            tab === 'debug'
+              ? 'border-b-2 border-brand font-medium'
+              : 'text-gray-500'
+          }`}
+        >
+          Debug
+        </button>
+      </div>
+
+      {tab === 'plans' && (
+        <div className="space-y-6">
+          {loadingPlans && <p>Carregando...</p>}
+          {planError && <p className="text-red-500">{planError}</p>}
+          {!loadingPlans && !planError &&
+            plans.map((plan) => (
+              <div key={plan.id} className="border rounded-md p-4 space-y-2">
+                <h2 className="font-semibold">{plan.name}</h2>
+                <div className="flex gap-4 flex-wrap">
+                  {MODULES.map((m) => (
+                    <label key={m} className="flex items-center gap-1">
+                      <input
+                        type="checkbox"
+                        checked={plan.features_json?.includes(m) ?? false}
+                        onChange={() => toggle(plan.id, m)}
+                      />
+                      {m}
+                    </label>
+                  ))}
+                </div>
+                <button
+                  onClick={() => save(plan)}
+                  className="px-3 py-1 bg-brand text-white rounded-md"
+                >
+                  Salvar
+                </button>
+              </div>
+            ))}
+        </div>
+      )}
+
+      {tab === 'debug' && (
+        <div className="space-y-4">
+          {loadingDebug && <p>Carregando...</p>}
+          {!loadingDebug && debug && (
+            <>
+              <div>
+                <h2 className="font-semibold">Empresa</h2>
+                <p>ID: {debug.companyId}</p>
+                <p>Plano: {debug.plan || 'N/A'}</p>
+              </div>
+              <div>
+                <h2 className="font-semibold">Módulos</h2>
+                <ul className="list-disc pl-5">
+                  {MODULES.map((m) => (
+                    <li key={m}>
+                      {m}: {debug.modules[m] ? 'habilitado' : 'bloqueado'}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div>
+                <h2 className="font-semibold">Features efetivas</h2>
+                <pre className="bg-gray-100 p-2 text-xs overflow-x-auto">
+                  {JSON.stringify(debug.effective_features, null, 2)}
+                </pre>
+              </div>
+              <div>
+                <h2 className="font-semibold">Scopes do usuário</h2>
+                <pre className="bg-gray-100 p-2 text-xs overflow-x-auto">
+                  {JSON.stringify(debug.user_scopes, null, 2)}
+                </pre>
+              </div>
+              <div>
+                <h2 className="font-semibold">Allowed fields</h2>
+                <pre className="bg-gray-100 p-2 text-xs overflow-x-auto">
+                  {JSON.stringify(debug.allowed_fields, null, 2)}
+                </pre>
+              </div>
+              {Object.keys(debug.errors).length > 0 && (
+                <div>
+                  <h2 className="font-semibold">Erros</h2>
+                  <pre className="bg-gray-100 p-2 text-xs overflow-x-auto">
+                    {JSON.stringify(debug.errors, null, 2)}
+                  </pre>
+                </div>
+              )}
+              {debug.trace && (
+                <div>
+                  <h2 className="font-semibold">Trace</h2>
+                  <pre className="bg-gray-100 p-2 text-xs overflow-x-auto">
+                    {JSON.stringify(debug.trace, null, 2)}
+                  </pre>
+                </div>
+              )}
+            </>
+          )}
+          {!loadingDebug && !debug && <p>Empresa não encontrada</p>}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/pages/api/admin/debug.ts
+++ b/pages/api/admin/debug.ts
@@ -1,0 +1,114 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const MODULES = ['employees', 'metrics', 'reports'] as const;
+
+function processEffectiveFeatures(plan: any, company: any) {
+  const effective: Record<string, boolean> = {};
+  if (Array.isArray(plan?.features_json)) {
+    for (const f of plan.features_json) {
+      if (MODULES.includes(f as any)) effective[f] = true;
+    }
+  }
+  if (company?.plan_overrides) Object.assign(effective, company.plan_overrides);
+  return effective;
+}
+
+async function getCompanyDebugSafe(supabase: SupabaseClient, companyId: string) {
+  const trace: any[] = [];
+  const errors: Record<string, string> = {};
+
+  const { data: company, error: companyErr } = await supabase
+    .from('companies')
+    .select('id,name,plan_id,plan_overrides')
+    .eq('id', companyId)
+    .single();
+  trace.push({ step: 'company', data: company, error: companyErr?.message });
+  if (companyErr) errors.company = companyErr.message;
+
+  const { data: admin, error: adminErr } = await supabase
+    .from('users')
+    .select('id,email,name')
+    .eq('company_id', companyId)
+    .maybeSingle();
+  trace.push({ step: 'users', data: admin, error: adminErr?.message });
+  if (adminErr) errors.users = adminErr.message;
+
+  const { data: employees, error: empErr } = await supabase
+    .from('companies_users')
+    .select('user_id,name,email,role,scopes,allowed_fields')
+    .eq('company_id', companyId);
+  trace.push({ step: 'companies_users', data: employees, error: empErr?.message });
+  if (empErr) errors.companies_users = empErr.message;
+
+  let plan = null;
+  if (company?.plan_id) {
+    const { data: p, error: pErr } = await supabase
+      .from('plans')
+      .select('id,name,features_json')
+      .eq('id', company.plan_id)
+      .maybeSingle();
+    trace.push({ step: 'plan_by_id', data: p, error: pErr?.message });
+    if (pErr) errors.plan = pErr.message;
+    plan = p;
+  }
+
+  return { company, admin, employees: employees || [], plan, trace, errors };
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end();
+
+  const token = req.headers.authorization?.replace('Bearer ', '');
+  if (!token) return res.status(401).json({ error: 'missing token' });
+
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const { data: user, error: userErr } = await supabaseAdmin.auth.getUser(token);
+  if (userErr || !user?.user) return res.status(401).json({ error: userErr?.message || 'invalid token' });
+  const userId = user.user.id;
+
+  await supabaseAdmin.rpc('debug_set_user_context', { user_uuid: userId });
+
+  const { data: cu } = await supabaseAdmin
+    .from('companies_users')
+    .select('company_id')
+    .eq('user_id', userId);
+  let companyId: string | null = cu?.[0]?.company_id || null;
+  if (!companyId) {
+    const { data: u } = await supabaseAdmin
+      .from('users')
+      .select('company_id')
+      .eq('id', userId)
+      .maybeSingle();
+    companyId = u?.company_id || null;
+  }
+  if (!companyId) return res.status(200).json({ companyId: null });
+
+  const safe = await getCompanyDebugSafe(supabaseAdmin, companyId);
+  if ((safe as any).error) return res.status(500).json(safe);
+
+  const effectiveFeatures = processEffectiveFeatures(safe.plan, safe.company);
+  const modules = {
+    employees: effectiveFeatures.employees || false,
+    metrics: effectiveFeatures.metrics || false,
+    reports: effectiveFeatures.reports || false,
+  };
+  const userScopes = safe.employees[0]?.scopes || {};
+  const allowedFields = safe.employees[0]?.allowed_fields || [];
+
+  return res.status(200).json({
+    company: {
+      id: safe.company?.id,
+      name: safe.company?.name,
+      plan: safe.plan?.name || 'N/A',
+    },
+    effective_features: effectiveFeatures,
+    modules,
+    user_scopes: userScopes,
+    allowed_fields: allowedFields,
+    trace: safe.trace,
+    errors: safe.errors,
+  });
+}

--- a/pages/api/company-users.ts
+++ b/pages/api/company-users.ts
@@ -1,0 +1,136 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+const VALID_ALLOWED = ['name', 'email', 'phone', 'position', 'salary', 'cpf'] as const;
+
+function normalizeAllowedFields(input: unknown): string[] {
+  if (Array.isArray(input)) return Array.from(new Set(input.map(String)));
+  if (typeof input === 'string') return [input];
+  return [];
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  switch (req.method) {
+    case 'POST': {
+      const { name, email, password, phone, position, company_id, scopes, allowed_fields } = req.body;
+      if (!name || !email || !password || !company_id)
+        return res.status(400).json({ error: 'Missing fields' });
+
+      const { data, error } = await supabaseAdmin.auth.admin.createUser({
+        email,
+        password,
+        phone: phone || undefined,
+        email_confirm: true,
+      });
+      if (error || !data.user)
+        return res.status(400).json({ error: error?.message });
+
+      const rawAllowed = normalizeAllowedFields(allowed_fields);
+      const sanitizedAllowed = rawAllowed.filter((f) =>
+        VALID_ALLOWED.includes(f as any)
+      );
+
+      const { error: linkError } = await supabaseAdmin
+        .from('companies_users')
+        .insert({
+          company_id,
+          user_id: data.user.id,
+          name,
+          email,
+          phone: phone || null,
+          position,
+          scopes: scopes || {},
+          allowed_fields: sanitizedAllowed,
+        });
+      if (linkError)
+        return res.status(400).json({ error: linkError.message });
+
+      return res.status(200).json({ user_id: data.user.id, allowed_fields: sanitizedAllowed });
+    }
+
+    case 'GET': {
+      const { company_id } = req.query;
+      const { data, error } = await supabaseAdmin
+        .from('companies_users')
+        .select('user_id, name, email, phone, position, scopes, allowed_fields')
+        .eq('company_id', company_id as string);
+      if (error) return res.status(400).json({ error: error.message });
+      return res.status(200).json(data);
+    }
+
+    case 'PUT': {
+      const { user_id, name, email, phone, position, password, scopes, allowed_fields, company_id } = req.body;
+      const rawAllowed = normalizeAllowedFields(allowed_fields);
+      const sanitizedAllowed = rawAllowed.filter((f) =>
+        VALID_ALLOWED.includes(f as any)
+      );
+      if (process.env.NODE_ENV !== 'production') {
+        console.log('[PUT /company-users] payload.allowed_fields (raw):', allowed_fields);
+        console.log('[PUT /company-users] payload.allowed_fields (sanitized):', sanitizedAllowed);
+      }
+      const authUpdates: { email?: string; password?: string; phone?: string } = {};
+      if (email) authUpdates.email = email;
+      if (password) authUpdates.password = password;
+      if (phone) authUpdates.phone = phone;
+
+      if (Object.keys(authUpdates).length) {
+        const { error: authError } = await supabaseAdmin.auth.admin.updateUserById(
+          user_id,
+          authUpdates
+        );
+        if (authError) return res.status(400).json({ error: authError.message });
+      }
+
+      const rowUpdates: {
+        name?: string;
+        email?: string;
+        phone?: string | null;
+        position?: string | null;
+        scopes?: any;
+        allowed_fields?: any;
+      } = {};
+      if (name) rowUpdates.name = name;
+      if (email) rowUpdates.email = email;
+      if (phone) rowUpdates.phone = phone;
+      if (position) rowUpdates.position = position;
+      if (scopes !== undefined) rowUpdates.scopes = scopes;
+      if (allowed_fields !== undefined) rowUpdates.allowed_fields = sanitizedAllowed;
+
+      if (Object.keys(rowUpdates).length) {
+        const { data, error: linkError } = await supabaseAdmin
+          .from('companies_users')
+          .update(rowUpdates)
+          .eq('user_id', user_id)
+          .eq('company_id', company_id)
+          .select('user_id, company_id, allowed_fields')
+          .single();
+        if (linkError) return res.status(400).json({ error: linkError.message });
+        return res.status(200).json({ ok: true, data });
+      }
+
+      return res.status(200).json({ ok: true, data: { user_id, company_id, allowed_fields: sanitizedAllowed } });
+    }
+
+    case 'DELETE': {
+      const { id, company_id } = req.query;
+      await supabaseAdmin
+        .from('companies_users')
+        .delete()
+        .eq('company_id', company_id as string)
+        .eq('user_id', id as string);
+      await supabaseAdmin.auth.admin.deleteUser(id as string);
+
+      return res.status(200).json({ ok: true });
+    }
+
+    default:
+      return res.status(405).end();
+  }
+}

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -6,10 +6,12 @@ import Layout from '../components/Layout';
 import { Button } from '../components/ui/button';
 import EmployeeStats from '../components/EmployeeStats';
 import { LogOut, Users, PlusCircle } from 'lucide-react';
+import { hasScope, SCOPE_DEFINITIONS } from '../lib/access';
 
 export default function Dashboard() {
   const [loading, setLoading] = useState(true);
   const [stats, setStats] = useState({ active: 0, inactive: 0, dismissed: 0 });
+  const [scopes, setScopes] = useState<Record<string, any>>({});
   const router = useRouter();
 
   useEffect(() => {
@@ -19,21 +21,42 @@ export default function Dashboard() {
         router.replace('/login');
         return;
       }
-      const { data: userProfile } = await supabase
-        .from('users')
-        .select('company_id')
-        .eq('id', session.session.user.id)
-        .single();
+      const { data: cu } = await supabase
+        .from('companies_users')
+        .select('company_id, scopes')
+        .eq('user_id', session.session.user.id);
+      const cuRow = cu && cu.length ? cu[0] : null;
+      let companyId = cuRow?.company_id;
+      if (cuRow?.scopes) {
+        setScopes(cuRow.scopes);
+      } else {
+        const allScopes: Record<string, Record<string, boolean>> = {};
+        Object.entries(SCOPE_DEFINITIONS).forEach(([mod, actions]) => {
+          allScopes[mod] = {};
+          Object.keys(actions).forEach((act) => (allScopes[mod][act] = true));
+        });
+        setScopes(allScopes);
+      }
+      if (!companyId) {
+        const { data: userProfile } = await supabase
+          .from('users')
+          .select('company_id')
+          .eq('id', session.session.user.id)
+          .single();
+        companyId = userProfile?.company_id;
+      }
       const { data: company } = await supabase
         .from('companies')
         .select('maxemployees')
-        .eq('id', userProfile?.company_id)
+        .eq('id', companyId)
         .single();
       if (company?.maxemployees === 0) {
-        router.replace(`/pending?companyId=${userProfile?.company_id}`);
+        router.replace(`/pending?companyId=${companyId}`);
         return;
       }
-      const { data: employees } = await supabase.from('employees').select('status');
+      const { data: employees } = await supabase
+        .from('employees')
+        .select('status');
       const active = employees?.filter((e) => e.status === 'active').length || 0;
       const inactive = employees?.filter((e) => e.status === 'inactive').length || 0;
       const dismissed = employees?.filter((e) => e.status === 'dismissed').length || 0;
@@ -60,16 +83,20 @@ export default function Dashboard() {
       </div>
       <EmployeeStats active={stats.active} inactive={stats.inactive} dismissed={stats.dismissed} />
       <div className="mt-8 flex gap-4">
-        <Button asChild>
-          <Link href="/employees" className="flex items-center gap-2">
-            <Users className="h-4 w-4" /> Funcionários
-          </Link>
-        </Button>
-        <Button variant="outline" asChild>
-          <Link href="/employees/new" className="flex items-center gap-2">
-            <PlusCircle className="h-4 w-4" /> Adicionar Funcionário
-          </Link>
-        </Button>
+        {hasScope(scopes, 'employees', 'read') && (
+          <Button asChild data-action="employees.read">
+            <Link href="/employees" className="flex items-center gap-2">
+              <Users className="h-4 w-4" /> Funcionários
+            </Link>
+          </Button>
+        )}
+        {hasScope(scopes, 'employees', 'create') && (
+          <Button variant="outline" asChild data-action="employees.create">
+            <Link href="/employees/new" className="flex items-center gap-2">
+              <PlusCircle className="h-4 w-4" /> Adicionar Funcionário
+            </Link>
+          </Button>
+        )}
       </div>
     </Layout>
   );

--- a/pages/employees/index.tsx
+++ b/pages/employees/index.tsx
@@ -8,6 +8,7 @@ import { Button } from '../../components/ui/button';
 import EmployeeViewModal from '../../components/EmployeeViewModal';
 import EmployeeConfigModal from '../../components/EmployeeConfigModal';
 import { getFieldLabel, FIELD_GROUPS } from '../../lib/utils';
+import { hasScope, SCOPE_DEFINITIONS, EMPLOYEE_FIELD_OPTIONS } from '../../lib/access';
 import {
   Users,
   UserPlus,
@@ -44,6 +45,8 @@ export default function Employees() {
   const [employees, setEmployees] = useState<Employee[]>([]);
   const [allColumns, setAllColumns] = useState<string[]>([]);
   const [columns, setColumns] = useState<string[]>([]);
+  const [allowedFields, setAllowedFields] = useState<string[]>([]);
+  const [scopes, setScopes] = useState<Record<string, any>>({});
   const [filters, setFilters] = useState<Filter[]>([]);
   const [views, setViews] = useState<any[]>([]);
   const [currentView, setCurrentView] = useState<any | null>(null);
@@ -98,33 +101,69 @@ export default function Employees() {
   };
 
   const load = async () => {
-    const { data: { session } } = await supabase.auth.getSession();
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
     if (!session) return;
-    const { data: user } = await supabase
-      .from('users')
-      .select('company_id')
-      .eq('id', session.user.id)
-      .single();
+    const { data: cu } = await supabase
+      .from('companies_users')
+      .select('company_id, allowed_fields, scopes')
+      .eq('user_id', session.user.id);
+    const cuRow = cu && cu.length ? cu[0] : null;
+    let companyId = cuRow?.company_id;
+    if (!companyId) {
+      const { data: user } = await supabase
+        .from('users')
+        .select('company_id')
+        .eq('id', session.user.id)
+        .single();
+      companyId = user.company_id;
+    }
     const { data: defs } = await supabase
       .from('custom_fields')
       .select('field,value')
-      .eq('company_id', user.company_id);
+      .eq('company_id', companyId);
     const defMap: Record<string, string[]> = {};
     defs?.forEach((d: any) => {
       defMap[d.field] = defMap[d.field] ? [...defMap[d.field], d.value] : [d.value];
     });
     setCustomFieldDefs(defMap);
+    let allowed = cuRow?.allowed_fields || [];
+    if (!cuRow) {
+      allowed = Array.from(
+        new Set([
+          ...Object.keys(EMPLOYEE_FIELD_OPTIONS),
+          ...Object.keys(defMap),
+        ])
+      );
+      const allScopes: Record<string, Record<string, boolean>> = {};
+      Object.entries(SCOPE_DEFINITIONS).forEach(([mod, actions]) => {
+        allScopes[mod] = {};
+        Object.keys(actions).forEach((act) => (allScopes[mod][act] = true));
+      });
+      setScopes(allScopes);
+    } else {
+      setScopes(cuRow.scopes || {});
+    }
+    setAllowedFields(allowed);
     const { data = [] } = await supabase
       .from('employees')
       .select('*')
-      .eq('company_id', user.company_id);
+      .eq('company_id', companyId);
     const expanded = data.map((emp) => ({ ...emp, ...emp.custom_fields }));
     setEmployees(expanded);
     refreshCounts(expanded);
     const cols = expanded.length
-      ? Object.keys(expanded[0]).filter((k) => k !== 'company_id' && k !== 'custom_fields')
+      ? Object.keys(expanded[0]).filter(
+          (k) =>
+            k !== 'company_id' &&
+            k !== 'custom_fields' &&
+            (!allowed.length || allowed.includes(k))
+        )
       : [];
-    const all = Array.from(new Set([...cols, ...Object.keys(defMap)]));
+    const all = Array.from(new Set([...cols, ...Object.keys(defMap)])).filter(
+      (c) => !allowed.length || allowed.includes(c)
+    );
     setAllColumns(all);
     const { data: viewRows } = await supabase
       .from('employee_views')
@@ -149,7 +188,14 @@ export default function Employees() {
       setViews(viewRows);
     }
     setCurrentView(view);
-    setColumns(view?.columns && view.columns.length ? view.columns : defaultViewCols);
+    const defaultCols = defaultViewCols.filter(
+      (c) => !allowed.length || allowed.includes(c)
+    );
+    const selected =
+      view?.columns && view.columns.length
+        ? view.columns.filter((c: string) => all.includes(c))
+        : defaultCols;
+    setColumns(selected);
     setFilters(view?.filters || []);
     setField(all[0] || '');
   };
@@ -160,7 +206,11 @@ export default function Employees() {
 
   const switchView = (v: any) => {
     setCurrentView(v);
-    setColumns(v.columns || []);
+    setColumns(
+      (v.columns || []).filter(
+        (c: string) => !allowedFields.length || allowedFields.includes(c)
+      )
+    );
     setFilters(v.filters || []);
     setField(allColumns[0] || '');
   };
@@ -433,11 +483,13 @@ export default function Employees() {
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-2xl font-bold">Funcionários</h1>
         <div className="flex gap-2">
-          <Button asChild>
-            <Link href="/employees/new" className="flex items-center gap-1">
-              <UserPlus className="h-4 w-4" /> Adicionar Funcionário
-            </Link>
-          </Button>
+          {hasScope(scopes, 'employees', 'create') && (
+            <Button asChild data-action="employees.create">
+              <Link href="/employees/new" className="flex items-center gap-1">
+                <UserPlus className="h-4 w-4" /> Adicionar Funcionário
+              </Link>
+            </Button>
+          )}
           <Button
             variant="outline"
             onClick={() => setConfigOpen(true)}
@@ -764,94 +816,118 @@ export default function Employees() {
           className="fixed bg-white border p-2 z-50 space-y-1 actions-menu"
           style={{ top: menuPos.y, left: menuPos.x }}
         >
-          <div>
-            <button
-              className="text-left text-sm text-brand hover:underline flex items-center gap-1"
-              onClick={() => {
-                setOpenActions(null);
-                setViewId(activeEmp.id);
-              }}
-            >
-              <Eye className="h-4 w-4" /> Visualizar
-            </button>
-          </div>
-          <div>
-            <button
-              className="text-left text-sm text-brand hover:underline flex items-center gap-1"
-              onClick={() => {
-                setOpenActions(null);
-                router.push(`/employees/${activeEmp.id}`);
-              }}
-            >
-              <Pencil className="h-4 w-4" /> Editar
-            </button>
-          </div>
+          {hasScope(scopes, 'employees', 'read') && (
+            <div>
+              <button
+                data-action="employees.read"
+                className="text-left text-sm text-brand hover:underline flex items-center gap-1"
+                onClick={() => {
+                  setOpenActions(null);
+                  setViewId(activeEmp.id);
+                }}
+              >
+                <Eye className="h-4 w-4" /> Visualizar
+              </button>
+            </div>
+          )}
+          {hasScope(scopes, 'employees', 'update') && (
+            <div>
+              <button
+                data-action="employees.update"
+                className="text-left text-sm text-brand hover:underline flex items-center gap-1"
+                onClick={() => {
+                  setOpenActions(null);
+                  router.push(`/employees/${activeEmp.id}`);
+                }}
+              >
+                <Pencil className="h-4 w-4" /> Editar
+              </button>
+            </div>
+          )}
           {activeEmp.status === 'active' ? (
             <>
-              <div>
-                <button
-                  className="text-left text-sm text-brand hover:underline flex items-center gap-1"
-                  onClick={() => updateStatus(activeEmp.id, 'inactive')}
-                >
-                  <UserMinus className="h-4 w-4" /> Inativar
-                </button>
-              </div>
-              <div>
-                <button
-                  className="text-left text-sm text-brand hover:underline flex items-center gap-1"
-                  onClick={() => {
-                    setOpenActions(null);
-                    setDismissDate(new Date().toISOString().slice(0, 10));
-                    setDismissReason('');
-                    setDismissId(activeEmp.id);
-                  }}
-                >
-                  <UserX className="h-4 w-4" /> Desligar
-                </button>
-              </div>
+              {hasScope(scopes, 'employees', 'deactivate') && (
+                <div>
+                  <button
+                    data-action="employees.deactivate"
+                    className="text-left text-sm text-brand hover:underline flex items-center gap-1"
+                    onClick={() => updateStatus(activeEmp.id, 'inactive')}
+                  >
+                    <UserMinus className="h-4 w-4" /> Inativar
+                  </button>
+                </div>
+              )}
+              {hasScope(scopes, 'employees', 'dismiss') && (
+                <div>
+                  <button
+                    data-action="employees.dismiss"
+                    className="text-left text-sm text-brand hover:underline flex items-center gap-1"
+                    onClick={() => {
+                      setOpenActions(null);
+                      setDismissDate(new Date().toISOString().slice(0, 10));
+                      setDismissReason('');
+                      setDismissId(activeEmp.id);
+                    }}
+                  >
+                    <UserX className="h-4 w-4" /> Desligar
+                  </button>
+                </div>
+              )}
             </>
           ) : activeEmp.status === 'inactive' ? (
             <>
+              {hasScope(scopes, 'employees', 'activate') && (
+                <div>
+                  <button
+                    data-action="employees.activate"
+                    className="text-left text-sm text-brand hover:underline flex items-center gap-1"
+                    onClick={() => updateStatus(activeEmp.id, 'active')}
+                  >
+                    <UserCheck className="h-4 w-4" /> Ativar
+                  </button>
+                </div>
+              )}
+              {hasScope(scopes, 'employees', 'dismiss') && (
+                <div>
+                  <button
+                    data-action="employees.dismiss"
+                    className="text-left text-sm text-brand hover:underline flex items-center gap-1"
+                    onClick={() => {
+                      setOpenActions(null);
+                      setDismissDate(new Date().toISOString().slice(0, 10));
+                      setDismissReason('');
+                      setDismissId(activeEmp.id);
+                    }}
+                  >
+                    <UserX className="h-4 w-4" /> Desligar
+                  </button>
+                </div>
+              )}
+            </>
+          ) : (
+            hasScope(scopes, 'employees', 'activate') && (
               <div>
                 <button
+                  data-action="employees.activate"
                   className="text-left text-sm text-brand hover:underline flex items-center gap-1"
                   onClick={() => updateStatus(activeEmp.id, 'active')}
                 >
                   <UserCheck className="h-4 w-4" /> Ativar
                 </button>
               </div>
-              <div>
-                <button
-                  className="text-left text-sm text-brand hover:underline flex items-center gap-1"
-                  onClick={() => {
-                    setOpenActions(null);
-                    setDismissDate(new Date().toISOString().slice(0, 10));
-                    setDismissReason('');
-                    setDismissId(activeEmp.id);
-                  }}
-                >
-                  <UserX className="h-4 w-4" /> Desligar
-                </button>
-              </div>
-            </>
-          ) : (
+            )
+          )}
+          {hasScope(scopes, 'employees', 'delete') && (
             <div>
               <button
-                className="text-left text-sm text-brand hover:underline flex items-center gap-1"
-                onClick={() => updateStatus(activeEmp.id, 'active')}
+                data-action="employees.delete"
+                className="text-left text-sm text-red-600 hover:underline flex items-center gap-1"
+                onClick={() => setDeleteId(activeEmp.id)}
               >
-                <UserCheck className="h-4 w-4" /> Ativar
+                <Trash className="h-4 w-4" /> Excluir
               </button>
             </div>
           )}
-          <div>
-            <button
-              className="text-left text-sm text-red-600 hover:underline flex items-center gap-1"
-              onClick={() => setDeleteId(activeEmp.id)}
-            >
-              <Trash className="h-4 w-4" /> Excluir
-            </button>
-          </div>
         </div>
       )}
       <EmployeeConfigModal

--- a/pages/users/index.tsx
+++ b/pages/users/index.tsx
@@ -1,0 +1,341 @@
+import { useEffect, useState } from 'react';
+import Layout from '../../components/Layout';
+import { supabase } from '../../lib/supabaseClient';
+import { Button } from '../../components/ui/button';
+import {
+  SCOPE_DEFINITIONS,
+  EMPLOYEE_FIELD_OPTIONS,
+} from '../../lib/access';
+
+interface CompanyUser {
+  user_id: string;
+  name: string;
+  email: string;
+  phone: string | null;
+  position: string | null;
+  scopes?: Record<string, any>;
+  allowed_fields?: string[];
+}
+
+export default function CompanyUsersPage() {
+  const [companyId, setCompanyId] = useState<string>('');
+  const [users, setUsers] = useState<CompanyUser[]>([]);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [phone, setPhone] = useState('');
+  const [position, setPosition] = useState('');
+  const [positions, setPositions] = useState<string[]>([]);
+  const [error, setError] = useState<string>('');
+  const [loadingCompany, setLoadingCompany] = useState(true);
+  const [accessUser, setAccessUser] = useState<CompanyUser | null>(null);
+  const [scopeState, setScopeState] = useState<
+    Record<string, Record<string, boolean>>
+  >({});
+  const FIELD_OPTIONS = Object.keys(EMPLOYEE_FIELD_OPTIONS) as Array<
+    keyof typeof EMPLOYEE_FIELD_OPTIONS
+  >;
+  type Field = (typeof FIELD_OPTIONS)[number];
+  const [allowedState, setAllowedState] = useState<Field[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  const loadUsers = async (cid: string) => {
+    const res = await fetch(`/api/company-users?company_id=${cid}`);
+    if (res.ok) {
+      const data = await res.json();
+      setUsers(data);
+    }
+  };
+
+  const loadPositions = async (cid: string) => {
+    const { data } = await supabase
+      .from('employees')
+      .select('position')
+      .eq('company_id', cid)
+      .not('position', 'is', null);
+    if (data) {
+      const unique = Array.from(new Set(data.map((e: any) => e.position)));
+      setPositions(unique as string[]);
+    }
+  };
+
+  useEffect(() => {
+    const init = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) {
+        setLoadingCompany(false);
+        return;
+      }
+      const { data } = await supabase
+        .from('companies_users')
+        .select('company_id')
+        .eq('user_id', session.user.id);
+      const cuRow = data && data.length ? data[0] : null;
+      if (cuRow) {
+        setCompanyId(cuRow.company_id);
+        loadUsers(cuRow.company_id);
+        loadPositions(cuRow.company_id);
+      } else {
+        const { data: fallback } = await supabase
+          .from('users')
+          .select('company_id')
+          .eq('id', session.user.id)
+          .single();
+        if (fallback) {
+          setCompanyId(fallback.company_id);
+          loadUsers(fallback.company_id);
+          loadPositions(fallback.company_id);
+        }
+      }
+      setLoadingCompany(false);
+    };
+    init();
+  }, []);
+
+  const addUser = async () => {
+    setError('');
+    if (!companyId) {
+      setError('Empresa não encontrada');
+      return;
+    }
+    const res = await fetch('/api/company-users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name,
+        email,
+        password,
+        phone,
+        position: position || null,
+        company_id: companyId,
+      }),
+    });
+    if (res.ok) {
+      setName('');
+      setEmail('');
+      setPassword('');
+      setPhone('');
+      setPosition('');
+      loadUsers(companyId);
+    } else {
+      const { error: err } = await res.json();
+      setError(err || 'Erro ao adicionar usuário');
+    }
+  };
+
+  const updateUser = async (u: CompanyUser) => {
+    const newName = prompt('Nome:', u.name);
+    const newEmail = prompt('Email:', u.email);
+    const newPhone = prompt('Telefone:', u.phone || '');
+    const newPosition = prompt('Cargo:', u.position || '');
+    const newPassword = prompt('Nova senha (deixe vazio para manter):');
+    await fetch('/api/company-users', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        user_id: u.user_id,
+        name: newName || undefined,
+        email: newEmail || undefined,
+        phone: newPhone || undefined,
+        position: newPosition || undefined,
+        password: newPassword || undefined,
+      }),
+    });
+    loadUsers(companyId);
+  };
+
+  const removeUser = async (u: CompanyUser) => {
+    if (!confirm('Excluir este usuário?')) return;
+    await fetch(`/api/company-users?id=${u.user_id}&company_id=${companyId}`, { method: 'DELETE' });
+    loadUsers(companyId);
+  };
+
+  const openAccessModal = (u: CompanyUser) => {
+    setAccessUser(u);
+    setScopeState(u.scopes || {});
+    setAllowedState(
+      Array.from(new Set((u.allowed_fields || []) as Field[]))
+    );
+  };
+
+  function toggleAllowed(field: Field, checked: boolean) {
+    setAllowedState((prev) =>
+      checked ? Array.from(new Set([...prev, field])) : prev.filter((f) => f !== field)
+    );
+  }
+
+  const saveAccess = async () => {
+    if (!accessUser) return;
+    setSaving(true);
+    try {
+      const res = await fetch('/api/company-users', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          user_id: accessUser.user_id,
+          company_id: companyId,
+          scopes: scopeState,
+          allowed_fields: Array.from(new Set(allowedState)),
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      console.log('saveAccess response', res.status, data);
+      if (!res.ok) {
+        setError(data.error || 'Erro ao salvar acesso');
+        return;
+      }
+      setAllowedState((data.data?.allowed_fields || []) as Field[]);
+      setAccessUser(null);
+      loadUsers(companyId);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Layout>
+      <h1 className="text-2xl font-bold mb-4">Usuários & Permissões</h1>
+      <div className="mb-6 flex gap-2 flex-wrap">
+        <input
+          type="text"
+          placeholder="Nome"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="border p-2 rounded"
+        />
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="border p-2 rounded"
+        />
+        <input
+          type="password"
+          placeholder="Senha"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2 rounded"
+        />
+        <input
+          type="text"
+          placeholder="Telefone"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          className="border p-2 rounded"
+        />
+        <select
+          value={position}
+          onChange={(e) => setPosition(e.target.value)}
+          className="border p-2 rounded"
+        >
+          <option value="">Selecione o cargo</option>
+          {positions.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+        <Button
+          onClick={addUser}
+          disabled={
+            loadingCompany || !name || !email || !password
+          }
+        >
+          Adicionar
+        </Button>
+      </div>
+      {error && <p className="text-red-500 mb-4">{error}</p>}
+      <table className="w-full text-left border-collapse">
+        <thead>
+          <tr>
+            <th className="p-2 border-b">Nome</th>
+            <th className="p-2 border-b">Email</th>
+            <th className="p-2 border-b">Telefone</th>
+            <th className="p-2 border-b">Cargo</th>
+            <th className="p-2 border-b">Ações</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((u) => (
+            <tr key={u.user_id}>
+              <td className="p-2 border-b">{u.name}</td>
+              <td className="p-2 border-b">{u.email}</td>
+              <td className="p-2 border-b">{u.phone || '-'}</td>
+              <td className="p-2 border-b">{u.position || '-'}</td>
+              <td className="p-2 border-b space-x-2">
+                <Button variant="outline" onClick={() => updateUser(u)}>
+                  Editar
+                </Button>
+                <Button variant="outline" onClick={() => openAccessModal(u)}>
+                  Configurar acesso
+                </Button>
+                <Button variant="outline" onClick={() => removeUser(u)}>
+                  Excluir
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {accessUser && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+          <div className="bg-white p-4 rounded w-full max-w-lg space-y-4 max-h-[80vh] overflow-y-auto">
+            <h2 className="text-xl font-semibold">Configurar acesso</h2>
+            {Object.entries(SCOPE_DEFINITIONS).map(([mod, acts]) => (
+              <div key={mod}>
+                <p className="font-semibold capitalize">{mod}</p>
+                {Object.entries(acts).map(([act, label]) => (
+                  <label key={act} className="block ml-4">
+                    <input
+                      type="checkbox"
+                      className="mr-2"
+                      checked={scopeState[mod]?.[act] || false}
+                      onChange={(e) =>
+                        setScopeState((prev) => ({
+                          ...prev,
+                          [mod]: {
+                            ...prev[mod],
+                            [act]: e.target.checked,
+                          },
+                        }))
+                      }
+                    />
+                    {label}
+                  </label>
+                ))}
+              </div>
+            ))}
+            <div>
+              <p className="font-semibold">Campos visíveis</p>
+              {Object.entries(EMPLOYEE_FIELD_OPTIONS).map(([field, label]) => (
+                <label key={field} className="block ml-4">
+                  <input
+                    type="checkbox"
+                    className="mr-2"
+                    checked={allowedState.includes(field as Field)}
+                    onChange={(e) =>
+                      toggleAllowed(field as Field, e.target.checked)
+                    }
+                  />
+                  {label}
+                </label>
+              ))}
+            </div>
+            <div className="flex justify-end gap-2 pt-2">
+              <Button variant="outline" onClick={() => setAccessUser(null)}>
+                Cancelar
+              </Button>
+              <Button onClick={saveAccess} disabled={saving}>
+                Salvar
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </Layout>
+  );
+}
+

--- a/supabase.sql
+++ b/supabase.sql
@@ -4,6 +4,7 @@ create table public.companies (
   email text,
   phone text,
   plan text,
+  plan_id uuid references public.plans(id),
   maxemployees integer
 );
 
@@ -12,7 +13,8 @@ create table public.users (
   name text,
   phone text,
   email text,
-  company_id uuid references public.companies(id)
+  company_id uuid references public.companies(id),
+  is_admin boolean default false
 );
 
 create table public.employees (
@@ -79,3 +81,335 @@ create table public.subscriptions (
   status text default 'pending',
   created_at timestamptz default now()
 );
+
+create table public.companies_users (
+  company_id uuid not null,
+  user_id uuid not null,
+  name text not null,
+  email text not null,
+  phone text,
+  position text,
+  role public.company_user_role not null default 'viewer'::company_user_role,
+  scopes jsonb not null default '{}'::jsonb,
+  allowed_fields jsonb not null default '[]'::jsonb,
+  created_at timestamp with time zone not null default now(),
+  constraint companies_users_pkey primary key (company_id, user_id),
+  constraint companies_users_company_id_fkey foreign key (company_id) references companies (id) on delete cascade,
+  constraint companies_users_user_id_fkey foreign key (user_id) references auth.users (id) on delete cascade,
+  constraint companies_users_allowed_fields_is_array check ((jsonb_typeof(allowed_fields) = 'array'::text)),
+  constraint companies_users_scopes_is_object check ((jsonb_typeof(scopes) = 'object'::text))
+);
+
+create index if not exists companies_users_company_id_idx on public.companies_users using btree (company_id);
+create index if not exists companies_users_user_id_idx on public.companies_users using btree (user_id);
+
+create or replace function trg_companies_users_validate_scopes()
+returns trigger as $$
+declare
+  module text;
+  features jsonb := app_effective_features(new.company_id);
+begin
+  if new.scopes is null then
+    return new;
+  end if;
+  for module in select jsonb_object_keys(new.scopes) loop
+    if not coalesce((features ->> module)::boolean, false) then
+      raise exception 'Módulo "%s" não permitido pelo plano/overrides da empresa.', module;
+    end if;
+  end loop;
+  return new;
+end;
+$$ language plpgsql security definer;
+
+create trigger companies_users_validate_scopes before insert or update on companies_users for each row execute function trg_companies_users_validate_scopes ();
+
+-- Snippet para atualizar bancos existentes
+-- alter table if exists public.users add column if not exists is_admin boolean default false;
+-- alter table if exists public.companies add column if not exists plan_id uuid;
+-- alter table public.companies add constraint companies_plan_id_fkey foreign key (plan_id) references public.plans(id);
+-- atualiza plan_id de empresas existentes com base no campo plan
+-- update public.companies c set plan_id = p.id from public.plans p where c.plan = p.name;
+-- limpa plan_id quando o plano informado não existe
+-- update public.companies set plan_id = null where plan is not null and plan not in (select name from public.plans);
+-- alter table if exists public.companies_users add column if not exists name text;
+-- alter table if exists public.companies_users add column if not exists email text;
+-- alter table if exists public.companies_users add column if not exists phone text;
+-- alter table if exists public.companies_users add column if not exists position text;
+-- popular features dos planos existentes quando estiverem nulos
+-- update public.plans set features_json = array['employees','metrics','reports'] where features_json is null;
+
+-- Helpers de acesso e planos
+create or replace function app_current_company_id() returns uuid
+language plpgsql
+stable
+security definer
+as $$
+declare
+  cid uuid;
+begin
+  -- avoid infinite recursion from RLS policies
+  begin
+    cid := current_setting('app.current_company_id', true)::uuid;
+    if cid is not null then
+      return cid;
+    end if;
+  exception when others then
+    -- setting not present
+    null;
+  end;
+
+  set local row_security = off;
+  select company_id into cid from public.companies_users
+  where user_id = auth.uid() limit 1;
+
+  if cid is null then
+    select company_id into cid from public.users where id = auth.uid();
+  end if;
+
+  perform set_config('app.current_company_id', coalesce(cid::text, ''), true);
+  return cid;
+end;
+$$;
+
+create or replace function app_is_superadmin() returns boolean as $$
+  select coalesce(is_admin, false) from public.users where id = auth.uid();
+$$ language sql stable;
+
+create or replace function app_effective_features(company uuid) returns jsonb as $$
+declare
+  use_plan_id boolean;
+  result jsonb;
+begin
+  select exists(
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'companies'
+      and column_name = 'plan_id'
+  ) into use_plan_id;
+
+  if use_plan_id then
+    execute $$
+      with raw as (
+        select c.plan_overrides,
+               coalesce(
+                 case
+                   when p.features_json is not null and pg_typeof(p.features_json)::text like 'json%'
+                     then p.features_json::jsonb
+                   when p.features_json is not null and array_length(p.features_json,1) = 1 and p.features_json[1] like '[%'
+                     then p.features_json[1]::jsonb
+                   when p.features_json is not null then to_jsonb(p.features_json)
+                   else null
+                 end,
+                 '["employees","metrics","reports"]'::jsonb
+               ) as features_json
+        from public.companies c
+        left join public.plans p on c.plan_id = p.id
+        where c.id = $1
+      )
+      select coalesce(
+               (
+                 select jsonb_object_agg(feature, true)
+                 from (
+                   select value as feature
+                   from jsonb_array_elements_text(raw.features_json) value
+                   where value in ('employees','metrics','reports')
+                 ) f
+               ),
+               '{}'::jsonb
+             ) || coalesce(raw.plan_overrides, '{}'::jsonb)
+      from raw
+      union all
+      select '{"employees":true,"metrics":true,"reports":true}'::jsonb
+      limit 1$$
+    into result using company;
+  else
+    execute $$
+      with raw as (
+        select c.plan_overrides,
+               coalesce(
+                 case
+                   when p.features_json is not null and pg_typeof(p.features_json)::text like 'json%'
+                     then p.features_json::jsonb
+                   when p.features_json is not null and array_length(p.features_json,1) = 1 and p.features_json[1] like '[%'
+                     then p.features_json[1]::jsonb
+                   when p.features_json is not null then to_jsonb(p.features_json)
+                   else null
+                 end,
+                 '["employees","metrics","reports"]'::jsonb
+               ) as features_json
+        from public.companies c
+        left join public.plans p on c.plan = p.name
+        where c.id = $1
+      )
+      select coalesce(
+               (
+                 select jsonb_object_agg(feature, true)
+                 from (
+                   select value as feature
+                   from jsonb_array_elements_text(raw.features_json) value
+                   where value in ('employees','metrics','reports')
+                 ) f
+               ),
+               '{}'::jsonb
+             ) || coalesce(raw.plan_overrides, '{}'::jsonb)
+      from raw
+      union all
+      select '{"employees":true,"metrics":true,"reports":true}'::jsonb
+      limit 1$$
+    into result using company;
+  end if;
+
+  if result is null then
+    result := '{"employees":true,"metrics":true,"reports":true}'::jsonb;
+  end if;
+
+  return result;
+end;
+$$ language plpgsql stable security definer;
+
+create or replace function app_feature_enabled(company uuid, module text) returns boolean as $$
+  select coalesce((app_effective_features(company)->>module)::boolean, false);
+$$ language sql stable;
+
+create or replace function app_allowed_fields(company uuid) returns text[] as $$
+  select
+    coalesce(
+      (
+        select array(select jsonb_array_elements_text(cu.allowed_fields))
+        from public.companies_users cu
+        where cu.company_id = company and cu.user_id = auth.uid()
+      ),
+      case
+        when exists(
+          select 1 from public.users u
+          where u.id = auth.uid() and u.company_id = company
+        ) then (
+          select array_agg(field) from (
+            select column_name::text as field
+            from information_schema.columns
+            where table_schema = 'public' and table_name = 'employees'
+            union
+            select distinct field from public.custom_fields cf where cf.company_id = company
+          ) allf
+        )
+        else array[]::text[]
+      end
+    );
+$$ language sql stable;
+
+create or replace function app_has_scope(company uuid, module text, action text) returns boolean as $$
+  select app_is_superadmin() or (
+    app_feature_enabled(company, module) and
+    coalesce(
+      (
+        select (cu.scopes -> module ->> action)::boolean
+        from public.companies_users cu
+        where cu.company_id = company and cu.user_id = auth.uid()
+      ),
+      exists(
+        select 1 from public.users u
+        where u.id = auth.uid() and u.company_id = company
+      )
+    )
+  );
+$$ language sql stable;
+
+-- RLS para employees
+alter table public.employees enable row level security;
+
+create policy employees_tenant_policy on public.employees
+  using (company_id = app_current_company_id() or app_is_superadmin())
+  with check (company_id = app_current_company_id() or app_is_superadmin());
+
+-- Listagem mascarada de funcionários
+create or replace function app_list_employees_masked(company uuid)
+returns setof public.employees as $$
+  select
+    id,
+    company_id,
+    case when 'name' = any(app_allowed_fields(company)) then name else null end as name,
+    case when 'email' = any(app_allowed_fields(company)) then email else null end as email,
+    case when 'phone' = any(app_allowed_fields(company)) then phone else null end as phone,
+    case when 'position' = any(app_allowed_fields(company)) then position else null end as position,
+    case when 'salary' = any(app_allowed_fields(company)) then salary else null end as salary,
+    case when 'cpf' = any(app_allowed_fields(company)) then cpf else null end as cpf,
+    street,
+    city,
+    state,
+    zip,
+    department,
+    hire_date,
+    termination_date,
+    termination_reason,
+    status,
+    gender,
+    emergency_contact_name,
+    emergency_contact_phone,
+    emergency_contact_relation,
+    resume_url,
+    comments,
+    custom_fields,
+    created_at
+  from public.employees
+  where company_id = company;
+$$ language sql stable;
+
+-- RPCs que reforçam permissões
+create or replace function app_employee_dismiss(emp_id uuid, reason text)
+returns void as $$
+declare company uuid;
+begin
+  select company_id into company from public.employees where id = emp_id;
+  if not app_has_scope(company, 'employees', 'dismiss') then
+    raise exception 'permission denied';
+  end if;
+  update public.employees
+    set status = 'dismissed', termination_reason = reason, termination_date = now()
+    where id = emp_id;
+end;
+$$ language plpgsql security definer;
+
+create or replace function app_employee_toggle_status(emp_id uuid, to_status text)
+returns void as $$
+declare company uuid;
+begin
+  select company_id into company from public.employees where id = emp_id;
+  if to_status = 'active' then
+    if not app_has_scope(company, 'employees', 'activate') then
+      raise exception 'permission denied';
+    end if;
+  else
+    if not app_has_scope(company, 'employees', 'deactivate') then
+      raise exception 'permission denied';
+    end if;
+  end if;
+  update public.employees set status = to_status where id = emp_id;
+end;
+$$ language plpgsql security definer;
+
+create or replace function app_employee_update_salary(emp_id uuid, new_salary numeric)
+returns void as $$
+declare company uuid;
+begin
+  select company_id into company from public.employees where id = emp_id;
+  if not app_has_scope(company, 'employees', 'update_salary') then
+    raise exception 'permission denied';
+  end if;
+  update public.employees set salary = new_salary where id = emp_id;
+end;
+$$ language plpgsql security definer;
+
+create or replace function app_employees_export(company uuid)
+returns setof public.employees as $$
+begin
+  if not app_has_scope(company, 'employees', 'export') then
+    raise exception 'permission denied';
+  end if;
+  return query select * from app_list_employees_masked(company);
+end;
+$$ language plpgsql security definer;
+
+-- Snippet para aplicar RLS em bancos existentes
+-- alter table if exists public.employees enable row level security;
+-- drop policy if exists employees_tenant_policy on public.employees;
+-- create policy employees_tenant_policy on public.employees using (company_id = app_current_company_id() or app_is_superadmin()) with check (company_id = app_current_company_id() or app_is_superadmin());


### PR DESCRIPTION
## Summary
- sanitize and validate `allowed_fields` in company-user API
- dedupe and persist allowed field selections on Users page with disabled save button

## Testing
- `npm test`
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_689f37a86218832da3ce2deb451419c7