### PR TITLE
feat: add company user management

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { LayoutDashboard, Users, User as UserIcon } from 'lucide-react';
+import { LayoutDashboard, Users, User as UserIcon, UserCog } from 'lucide-react';
 import { cn } from '../lib/utils';
 import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
@@ -27,6 +27,7 @@ export default function Sidebar() {
   const links = [
     { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { href: '/employees', label: 'Funcionários', icon: Users },
+    { href: '/users', label: 'Usuários & Permissões', icon: UserCog },
   ];
 
   return (

--- a/pages/api/company-users.ts
+++ b/pages/api/company-users.ts
@@ -1,0 +1,41 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string;
+
+const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    const { email, password, name, phone, position, company_id } = req.body;
+
+    const { data: userData, error: authError } = await supabase.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+      user_metadata: { name, phone },
+    });
+
+    if (authError || !userData.user) {
+      return res.status(400).json({ error: authError?.message || 'Erro ao criar usuário' });
+    }
+
+    const userId = userData.user.id;
+
+    const { data: companyUser, error: insertError } = await supabase
+      .from('companies_users')
+      .insert({ company_id, user_id: userId, name, email, phone, position })
+      .select('user_id,name,email,phone,position')
+      .single();
+
+    if (insertError) {
+      return res.status(400).json({ error: insertError.message });
+    }
+
+    return res.status(200).json({ user: companyUser });
+  }
+
+  res.setHeader('Allow', ['POST']);
+  return res.status(405).end('Method Not Allowed');
+}

--- a/pages/users/index.tsx
+++ b/pages/users/index.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from 'react';
+import Layout from '../../components/Layout';
+import { supabase } from '../../lib/supabaseClient';
+import { Input } from '../../components/ui/input';
+import { Button } from '../../components/ui/button';
+import PositionSidebar from '../../components/PositionSidebar';
+
+interface CompanyUser {
+  user_id: string;
+  name: string;
+  email: string;
+  phone: string;
+  position: string | null;
+}
+
+export default function CompanyUsersPage() {
+  const [users, setUsers] = useState<CompanyUser[]>([]);
+  const [companyId, setCompanyId] = useState('');
+  const [positions, setPositions] = useState<string[]>([]);
+  const [posOpen, setPosOpen] = useState(false);
+
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [password, setPassword] = useState('');
+  const [position, setPosition] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) return;
+      const { data: user } = await supabase
+        .from('users')
+        .select('company_id')
+        .eq('id', session.user.id)
+        .single();
+      if (!user) return;
+      setCompanyId(user.company_id);
+      const { data: posData } = await supabase
+        .from('positions')
+        .select('name')
+        .eq('company_id', user.company_id);
+      setPositions(posData?.map((p: any) => p.name) || []);
+      const { data: companyUsers } = await supabase
+        .from('companies_users')
+        .select('user_id,name,email,phone,position')
+        .eq('company_id', user.company_id);
+      setUsers(companyUsers || []);
+    };
+    load();
+  }, []);
+
+  const addUser = async () => {
+    const res = await fetch('/api/company-users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email,
+        password,
+        name,
+        phone,
+        position,
+        company_id: companyId,
+      }),
+    });
+    const data = await res.json();
+    if (data.error) {
+      alert(data.error);
+    } else {
+      setUsers([...users, data.user]);
+      setName('');
+      setEmail('');
+      setPhone('');
+      setPassword('');
+      setPosition('');
+    }
+  };
+
+  return (
+    <Layout>
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold mb-4">Usuários & Permissões</h1>
+        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 mb-4">
+          <Input
+            placeholder="Nome"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <Input
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <Input
+            placeholder="Telefone"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+          />
+          <Input
+            placeholder="Senha"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <div className="flex items-center gap-2">
+            <select
+              className="border p-2 rounded w-full"
+              value={position}
+              onChange={(e) => setPosition(e.target.value)}
+            >
+              <option value="">Cargo</option>
+              {positions.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+            <Button type="button" variant="outline" size="sm" onClick={() => setPosOpen(true)}>
+              Cargos
+            </Button>
+          </div>
+          <Button className="sm:col-span-2 lg:col-span-3" onClick={addUser} disabled={!name || !email || !password}>
+            Adicionar
+          </Button>
+        </div>
+        <table className="w-full text-left border">
+          <thead>
+            <tr className="border-b">
+              <th className="p-2">Nome</th>
+              <th className="p-2">Email</th>
+              <th className="p-2">Telefone</th>
+              <th className="p-2">Cargo</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((u) => (
+              <tr key={u.user_id} className="border-b">
+                <td className="p-2">{u.name}</td>
+                <td className="p-2">{u.email}</td>
+                <td className="p-2">{u.phone}</td>
+                <td className="p-2">{u.position}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <PositionSidebar
+        open={posOpen}
+        onClose={() => {
+          setPosOpen(false);
+          supabase
+            .from('positions')
+            .select('name')
+            .eq('company_id', companyId)
+            .then(({ data }) => setPositions(data?.map((p: any) => p.name) || []));
+        }}
+      />
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- add sidebar link for user & permission management
- create API route to register company users via Supabase
- build user management page with form and position selector

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1b8095000832d80ba40f5202df39b