### PR TITLE
feat: add company user management

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { LayoutDashboard, Users, User as UserIcon } from 'lucide-react';
+import { LayoutDashboard, Users, User as UserIcon, UserCog } from 'lucide-react';
 import { cn } from '../lib/utils';
 import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
@@ -27,6 +27,7 @@ export default function Sidebar() {
   const links = [
     { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { href: '/employees', label: 'Funcionários', icon: Users },
+    { href: '/users', label: 'Usuários & Permissões', icon: UserCog },
   ];
 
   return (

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -10,6 +10,7 @@ const buttonVariants = cva(
       variant: {
         default: 'bg-brand text-white hover:bg-brand/90',
         outline: 'border border-brand text-brand hover:bg-brand/10',
+        destructive: 'bg-red-500 text-white hover:bg-red-600',
       },
       size: {
         default: 'h-10 px-4 py-2',

--- a/pages/api/company-users.ts
+++ b/pages/api/company-users.ts
@@ -1,0 +1,99 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string;
+
+const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    const { email, password, name, phone, position, company_id } = req.body;
+
+    const { data: userData, error: authError } = await supabase.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+      user_metadata: { name, phone },
+    });
+
+    if (authError || !userData.user) {
+      return res.status(400).json({ error: authError?.message || 'Erro ao criar usuário' });
+    }
+
+    const userId = userData.user.id;
+
+    const { data: companyUser, error: insertError } = await supabase
+      .from('companies_users')
+      .insert({ company_id, user_id: userId, name, email, phone, position })
+      .select('user_id,name,email,phone,position')
+      .single();
+
+    if (insertError) {
+      return res.status(400).json({ error: insertError.message });
+    }
+
+    return res.status(200).json({ user: companyUser });
+  }
+
+  if (req.method === 'PUT') {
+    const { user_id, company_id, name, email, phone, position, password } = req.body;
+
+    const updateAuthPayload: any = {
+      email,
+      user_metadata: { name, phone },
+    };
+
+    if (password) {
+      updateAuthPayload.password = password;
+    }
+
+    const { error: updateAuthError } = await supabase.auth.admin.updateUserById(
+      user_id,
+      updateAuthPayload
+    );
+
+    if (updateAuthError) {
+      return res.status(400).json({ error: updateAuthError.message });
+    }
+
+    const { data: updatedUser, error: updateError } = await supabase
+      .from('companies_users')
+      .update({ name, email, phone, position })
+      .eq('company_id', company_id)
+      .eq('user_id', user_id)
+      .select('user_id,name,email,phone,position')
+      .single();
+
+    if (updateError) {
+      return res.status(400).json({ error: updateError.message });
+    }
+
+    return res.status(200).json({ user: updatedUser });
+  }
+
+  if (req.method === 'DELETE') {
+    const { user_id, company_id } = req.body;
+
+    const { error: deleteCompanyUserError } = await supabase
+      .from('companies_users')
+      .delete()
+      .eq('company_id', company_id)
+      .eq('user_id', user_id);
+
+    if (deleteCompanyUserError) {
+      return res.status(400).json({ error: deleteCompanyUserError.message });
+    }
+
+    const { error: deleteAuthError } = await supabase.auth.admin.deleteUser(user_id);
+
+    if (deleteAuthError) {
+      return res.status(400).json({ error: deleteAuthError.message });
+    }
+
+    return res.status(200).json({ success: true });
+  }
+
+  res.setHeader('Allow', ['POST', 'PUT', 'DELETE']);
+  return res.status(405).end('Method Not Allowed');
+}

--- a/pages/users/index.tsx
+++ b/pages/users/index.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useState } from 'react';
+import Layout from '../../components/Layout';
+import { supabase } from '../../lib/supabaseClient';
+import { Input } from '../../components/ui/input';
+import { Button } from '../../components/ui/button';
+import PositionSidebar from '../../components/PositionSidebar';
+
+interface CompanyUser {
+  user_id: string;
+  name: string;
+  email: string;
+  phone: string;
+  position: string | null;
+}
+
+export default function CompanyUsersPage() {
+  const [users, setUsers] = useState<CompanyUser[]>([]);
+  const [companyId, setCompanyId] = useState('');
+  const [positions, setPositions] = useState<string[]>([]);
+  const [posOpen, setPosOpen] = useState(false);
+
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [password, setPassword] = useState('');
+  const [position, setPosition] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) return;
+      const { data: user } = await supabase
+        .from('users')
+        .select('company_id')
+        .eq('id', session.user.id)
+        .single();
+      if (!user) return;
+      setCompanyId(user.company_id);
+      const { data: posData } = await supabase
+        .from('positions')
+        .select('name')
+        .eq('company_id', user.company_id);
+      setPositions(posData?.map((p: any) => p.name) || []);
+      const { data: companyUsers } = await supabase
+        .from('companies_users')
+        .select('user_id,name,email,phone,position')
+        .eq('company_id', user.company_id);
+      setUsers(companyUsers || []);
+    };
+    load();
+  }, []);
+
+  const saveUser = async () => {
+    const method = editingId ? 'PUT' : 'POST';
+    const res = await fetch('/api/company-users', {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        user_id: editingId,
+        email,
+        password: password || undefined,
+        name,
+        phone,
+        position,
+        company_id: companyId,
+      }),
+    });
+    const data = await res.json();
+    if (data.error) {
+      alert(data.error);
+    } else {
+      if (editingId) {
+        setUsers(users.map((u) => (u.user_id === editingId ? data.user : u)));
+      } else {
+        setUsers([...users, data.user]);
+      }
+      setEditingId(null);
+      setName('');
+      setEmail('');
+      setPhone('');
+      setPassword('');
+      setPosition('');
+    }
+  };
+
+  const startEdit = (u: CompanyUser) => {
+    setEditingId(u.user_id);
+    setName(u.name);
+    setEmail(u.email);
+    setPhone(u.phone);
+    setPosition(u.position || '');
+  };
+
+  const deleteUser = async (user_id: string) => {
+    if (!confirm('Excluir este usuário?')) return;
+    const res = await fetch('/api/company-users', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id, company_id: companyId }),
+    });
+    const data = await res.json();
+    if (data.error) {
+      alert(data.error);
+    } else {
+      setUsers(users.filter((u) => u.user_id !== user_id));
+    }
+  };
+
+  return (
+    <Layout>
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold mb-4">Usuários & Permissões</h1>
+        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 mb-4">
+          <Input
+            placeholder="Nome"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <Input
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <Input
+            placeholder="Telefone"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+          />
+          <Input
+            placeholder="Senha"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <div className="flex items-center gap-2">
+            <select
+              className="border p-2 rounded w-full"
+              value={position}
+              onChange={(e) => setPosition(e.target.value)}
+            >
+              <option value="">Cargo</option>
+              {positions.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+            <Button type="button" variant="outline" size="sm" onClick={() => setPosOpen(true)}>
+              Cargos
+            </Button>
+          </div>
+          <div className="sm:col-span-2 lg:col-span-3 flex gap-2">
+            <Button onClick={saveUser} disabled={!name || !email || (!password && !editingId)}>
+              {editingId ? 'Salvar' : 'Adicionar'}
+            </Button>
+            {editingId && (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setEditingId(null);
+                  setName('');
+                  setEmail('');
+                  setPhone('');
+                  setPassword('');
+                  setPosition('');
+                }}
+              >
+                Cancelar
+              </Button>
+            )}
+          </div>
+        </div>
+        <table className="w-full text-left border">
+          <thead>
+            <tr className="border-b">
+              <th className="p-2">Nome</th>
+              <th className="p-2">Email</th>
+              <th className="p-2">Telefone</th>
+              <th className="p-2">Cargo</th>
+              <th className="p-2">Ações</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((u) => (
+              <tr key={u.user_id} className="border-b">
+                <td className="p-2">{u.name}</td>
+                <td className="p-2">{u.email}</td>
+                <td className="p-2">{u.phone}</td>
+                <td className="p-2">{u.position}</td>
+                <td className="p-2 flex gap-2">
+                  <Button size="sm" variant="outline" onClick={() => startEdit(u)}>
+                    Editar
+                  </Button>
+                  <Button size="sm" variant="destructive" onClick={() => deleteUser(u.user_id)}>
+                    Excluir
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <PositionSidebar
+        open={posOpen}
+        onClose={() => {
+          setPosOpen(false);
+          supabase
+            .from('positions')
+            .select('name')
+            .eq('company_id', companyId)
+            .then(({ data }) => setPositions(data?.map((p: any) => p.name) || []));
+        }}
+      />
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- add sidebar link for user & permission management
- create API route to register company users via Supabase
- build user management page with form and position selector
- enable updating and deleting company users from API and UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1b8095000832d80ba40f5202df39b