### PR TITLE
feat: add company user management

### DIFF
--- a/components/EmployeeForm.tsx
+++ b/components/EmployeeForm.tsx
@@ -21,6 +21,7 @@ interface Employee {
   zip: string;
   position: string;
   department: string;
+  unit: string;
   salary: string;
   hire_date: string;
   status: string;
@@ -45,6 +46,7 @@ const defaultEmployee: Employee = {
   zip: '',
   position: '',
   department: '',
+  unit: '',
   salary: '',
   hire_date: '',
   status: 'active',
@@ -65,6 +67,7 @@ export default function EmployeeForm({ employee }: { employee?: Employee }) {
   const [customFieldDefs, setCustomFieldDefs] = useState<Record<string, string[]>>({});
   const [departments, setDepartments] = useState<string[]>([]);
   const [positions, setPositions] = useState<string[]>([]);
+  const [units, setUnits] = useState<string[]>([]);
   const [fieldOpen, setFieldOpen] = useState(false);
   const [deptOpen, setDeptOpen] = useState(false);
   const [posOpen, setPosOpen] = useState(false);
@@ -178,6 +181,11 @@ export default function EmployeeForm({ employee }: { employee?: Employee }) {
       .select('name')
       .eq('company_id', user.company_id);
     setPositions(poss?.map((p: any) => p.name) || []);
+    const { data: unitRows } = await supabase
+      .from('companies_units')
+      .select('name')
+      .eq('company_id', user.company_id);
+    setUnits(unitRows?.map((u: any) => u.name) || []);
   };
 
   useEffect(() => {
@@ -215,6 +223,7 @@ export default function EmployeeForm({ employee }: { employee?: Employee }) {
     const payload = {
       ...form,
       salary: parseCurrency(form.salary) || null,
+      unit: form.unit || null,
       company_id: company.id,
     };
     if (isEdit && employee) {
@@ -403,6 +412,25 @@ export default function EmployeeForm({ employee }: { employee?: Employee }) {
               </Button>
             </div>
           </div>
+          {units.length > 0 && (
+            <div className="flex flex-col">
+              <label htmlFor="unit">Filial</label>
+              <select
+                id="unit"
+                name="unit"
+                value={form.unit}
+                onChange={handleChange}
+                className="border p-2 rounded"
+              >
+                <option value="">Selecione</option>
+                {units.map((u) => (
+                  <option key={u} value={u}>
+                    {u}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
           <div className="flex flex-col">
             <label htmlFor="salary">Salário</label>
             <Input

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { LayoutDashboard, Users, User as UserIcon } from 'lucide-react';
+import { LayoutDashboard, Users, User as UserIcon, UserCog } from 'lucide-react';
 import { cn } from '../lib/utils';
 import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
@@ -27,6 +27,7 @@ export default function Sidebar() {
   const links = [
     { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
     { href: '/employees', label: 'Funcionários', icon: Users },
+    { href: '/users', label: 'Usuários & Permissões', icon: UserCog },
   ];
 
   return (

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -10,6 +10,7 @@ const buttonVariants = cva(
       variant: {
         default: 'bg-brand text-white hover:bg-brand/90',
         outline: 'border border-brand text-brand hover:bg-brand/10',
+        destructive: 'bg-red-500 text-white hover:bg-red-600',
       },
       size: {
         default: 'h-10 px-4 py-2',

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -22,6 +22,7 @@ export const FIELD_LABELS: Record<string, string> = {
   zip: 'CEP',
   position: 'Cargo',
   department: 'Departamento',
+  unit: 'Filial',
   salary: 'Salário',
   hire_date: 'Data de admissão',
   termination_date: 'Data de desligamento',
@@ -47,7 +48,7 @@ export const FIELD_GROUPS = [
   { title: 'Endereço', fields: ['street', 'city', 'state', 'zip'] },
   {
     title: 'Informações profissionais',
-    fields: ['position', 'department', 'salary', 'hire_date', 'status'],
+    fields: ['position', 'department', 'unit', 'salary', 'hire_date', 'status'],
   },
   {
     title: 'Contato de emergência',

--- a/pages/api/company-units.ts
+++ b/pages/api/company-units.ts
@@ -1,0 +1,99 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string;
+
+const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    const { email, password, name, phone, company_id } = req.body;
+
+    const { data: userData, error: authError } = await supabase.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+      user_metadata: { name, phone },
+    });
+
+    if (authError || !userData.user) {
+      return res.status(400).json({ error: authError?.message || 'Erro ao criar usuário' });
+    }
+
+    const userId = userData.user.id;
+
+    const { data: unit, error: insertError } = await supabase
+      .from('companies_units')
+      .insert({ company_id, user_id: userId, name, email, phone })
+      .select('user_id,name,email,phone')
+      .single();
+
+    if (insertError) {
+      return res.status(400).json({ error: insertError.message });
+    }
+
+    return res.status(200).json({ user: unit });
+  }
+
+  if (req.method === 'PUT') {
+    const { user_id, company_id, name, email, phone, password } = req.body;
+
+    const updateAuthPayload: any = {
+      email,
+      user_metadata: { name, phone },
+    };
+
+    if (password) {
+      updateAuthPayload.password = password;
+    }
+
+    const { error: updateAuthError } = await supabase.auth.admin.updateUserById(
+      user_id,
+      updateAuthPayload
+    );
+
+    if (updateAuthError) {
+      return res.status(400).json({ error: updateAuthError.message });
+    }
+
+    const { data: updatedUnit, error: updateError } = await supabase
+      .from('companies_units')
+      .update({ name, email, phone })
+      .eq('company_id', company_id)
+      .eq('user_id', user_id)
+      .select('user_id,name,email,phone')
+      .single();
+
+    if (updateError) {
+      return res.status(400).json({ error: updateError.message });
+    }
+
+    return res.status(200).json({ user: updatedUnit });
+  }
+
+  if (req.method === 'DELETE') {
+    const { user_id, company_id } = req.body;
+
+    const { error: deleteUnitError } = await supabase
+      .from('companies_units')
+      .delete()
+      .eq('company_id', company_id)
+      .eq('user_id', user_id);
+
+    if (deleteUnitError) {
+      return res.status(400).json({ error: deleteUnitError.message });
+    }
+
+    const { error: deleteAuthError } = await supabase.auth.admin.deleteUser(user_id);
+
+    if (deleteAuthError) {
+      return res.status(400).json({ error: deleteAuthError.message });
+    }
+
+    return res.status(200).json({ success: true });
+  }
+
+  res.setHeader('Allow', ['POST', 'PUT', 'DELETE']);
+  return res.status(405).end('Method Not Allowed');
+}

--- a/pages/api/company-users.ts
+++ b/pages/api/company-users.ts
@@ -1,0 +1,99 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string;
+
+const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    const { email, password, name, phone, position, company_id } = req.body;
+
+    const { data: userData, error: authError } = await supabase.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+      user_metadata: { name, phone },
+    });
+
+    if (authError || !userData.user) {
+      return res.status(400).json({ error: authError?.message || 'Erro ao criar usuário' });
+    }
+
+    const userId = userData.user.id;
+
+    const { data: companyUser, error: insertError } = await supabase
+      .from('companies_users')
+      .insert({ company_id, user_id: userId, name, email, phone, position })
+      .select('user_id,name,email,phone,position')
+      .single();
+
+    if (insertError) {
+      return res.status(400).json({ error: insertError.message });
+    }
+
+    return res.status(200).json({ user: companyUser });
+  }
+
+  if (req.method === 'PUT') {
+    const { user_id, company_id, name, email, phone, position, password } = req.body;
+
+    const updateAuthPayload: any = {
+      email,
+      user_metadata: { name, phone },
+    };
+
+    if (password) {
+      updateAuthPayload.password = password;
+    }
+
+    const { error: updateAuthError } = await supabase.auth.admin.updateUserById(
+      user_id,
+      updateAuthPayload
+    );
+
+    if (updateAuthError) {
+      return res.status(400).json({ error: updateAuthError.message });
+    }
+
+    const { data: updatedUser, error: updateError } = await supabase
+      .from('companies_users')
+      .update({ name, email, phone, position })
+      .eq('company_id', company_id)
+      .eq('user_id', user_id)
+      .select('user_id,name,email,phone,position')
+      .single();
+
+    if (updateError) {
+      return res.status(400).json({ error: updateError.message });
+    }
+
+    return res.status(200).json({ user: updatedUser });
+  }
+
+  if (req.method === 'DELETE') {
+    const { user_id, company_id } = req.body;
+
+    const { error: deleteCompanyUserError } = await supabase
+      .from('companies_users')
+      .delete()
+      .eq('company_id', company_id)
+      .eq('user_id', user_id);
+
+    if (deleteCompanyUserError) {
+      return res.status(400).json({ error: deleteCompanyUserError.message });
+    }
+
+    const { error: deleteAuthError } = await supabase.auth.admin.deleteUser(user_id);
+
+    if (deleteAuthError) {
+      return res.status(400).json({ error: deleteAuthError.message });
+    }
+
+    return res.status(200).json({ success: true });
+  }
+
+  res.setHeader('Allow', ['POST', 'PUT', 'DELETE']);
+  return res.status(405).end('Method Not Allowed');
+}

--- a/pages/employees/[id].tsx
+++ b/pages/employees/[id].tsx
@@ -10,7 +10,7 @@ export default function EditEmployee() {
   const [employee, setEmployee] = useState<any>(null);
 
   useEffect(() => {
-    if (!id) return;
+    if (!id || id === 'new') return;
     const load = async () => {
       const { data } = await supabase
         .from('employees')
@@ -22,7 +22,16 @@ export default function EditEmployee() {
     load();
   }, [id]);
 
+  if (id === 'new') {
+    return (
+      <Layout>
+        <EmployeeForm />
+      </Layout>
+    );
+  }
+
   if (!employee) return <p>Carregando...</p>;
+
   return (
     <Layout>
       <EmployeeForm employee={employee} />

--- a/pages/employees/index.tsx
+++ b/pages/employees/index.tsx
@@ -23,7 +23,7 @@ import {
   Trash,
 } from 'lucide-react';
 
-const defaultViewCols = ['name','email','phone','cpf','position','department'];
+const defaultViewCols = ['name','email','phone','cpf','position','department','unit'];
 
 interface Employee {
   id: string;
@@ -48,6 +48,8 @@ export default function Employees() {
   const [views, setViews] = useState<any[]>([]);
   const [currentView, setCurrentView] = useState<any | null>(null);
   const [counts, setCounts] = useState({ active: 0, inactive: 0, dismissed: 0 });
+  const [units, setUnits] = useState<string[]>([]);
+  const [unitFilter, setUnitFilter] = useState('');
   const [field, setField] = useState('');
   const [value, setValue] = useState('');
   const [textValue, setTextValue] = useState('');
@@ -114,6 +116,11 @@ export default function Employees() {
       defMap[d.field] = defMap[d.field] ? [...defMap[d.field], d.value] : [d.value];
     });
     setCustomFieldDefs(defMap);
+    const { data: unitRows } = await supabase
+      .from('companies_units')
+      .select('name')
+      .eq('company_id', user.company_id);
+    setUnits(unitRows?.map((u: any) => u.name) || []);
     const { data = [] } = await supabase
       .from('employees')
       .select('*')
@@ -324,8 +331,10 @@ export default function Employees() {
     setDeleteId(null);
   };
 
-  const filtered = employees.filter((emp) =>
-    filters.every((f) => {
+  const filtered = employees.filter(
+    (emp) =>
+      (!unitFilter || emp.unit === unitFilter) &&
+      filters.every((f) => {
       const fieldValue = f.custom
         ? emp.custom_fields?.[f.field]
         : emp[f.field];
@@ -470,6 +479,20 @@ export default function Employees() {
               </option>
             ))}
           </select>
+          {units.length > 0 && (
+            <select
+              className="border rounded p-1"
+              value={unitFilter}
+              onChange={(e) => setUnitFilter(e.target.value)}
+            >
+              <option value="">Todas as filiais</option>
+              {units.map((u) => (
+                <option key={u} value={u}>
+                  {u}
+                </option>
+              ))}
+            </select>
+          )}
           <Button variant="outline" size="sm" onClick={addView}>
             Nova lista
           </Button>

--- a/pages/users/index.tsx
+++ b/pages/users/index.tsx
@@ -1,0 +1,352 @@
+import { useEffect, useState } from 'react';
+import Layout from '../../components/Layout';
+import { supabase } from '../../lib/supabaseClient';
+import { Input } from '../../components/ui/input';
+import { Button } from '../../components/ui/button';
+import PositionSidebar from '../../components/PositionSidebar';
+
+interface CompanyUser {
+  user_id: string;
+  name: string;
+  email: string;
+  phone: string;
+  position: string | null;
+}
+
+interface CompanyUnit {
+  user_id: string;
+  name: string;
+  email: string;
+  phone: string;
+}
+
+export default function CompanyUsersPage() {
+  const [tab, setTab] = useState<'users' | 'units'>('users');
+  const [users, setUsers] = useState<CompanyUser[]>([]);
+  const [units, setUnits] = useState<CompanyUnit[]>([]);
+  const [companyId, setCompanyId] = useState('');
+  const [positions, setPositions] = useState<string[]>([]);
+  const [posOpen, setPosOpen] = useState(false);
+
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [password, setPassword] = useState('');
+  const [position, setPosition] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const [uName, setUName] = useState('');
+  const [uEmail, setUEmail] = useState('');
+  const [uPhone, setUPhone] = useState('');
+  const [uPassword, setUPassword] = useState('');
+  const [unitEditingId, setUnitEditingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) return;
+      const { data: user } = await supabase
+        .from('users')
+        .select('company_id')
+        .eq('id', session.user.id)
+        .single();
+      if (!user) return;
+      setCompanyId(user.company_id);
+      const { data: posData } = await supabase
+        .from('positions')
+        .select('name')
+        .eq('company_id', user.company_id);
+      setPositions(posData?.map((p: any) => p.name) || []);
+      const { data: companyUsers } = await supabase
+        .from('companies_users')
+        .select('user_id,name,email,phone,position')
+        .eq('company_id', user.company_id);
+      setUsers(companyUsers || []);
+      const { data: companyUnits } = await supabase
+        .from('companies_units')
+        .select('user_id,name,email,phone')
+        .eq('company_id', user.company_id);
+      setUnits(companyUnits || []);
+    };
+    load();
+  }, []);
+
+  const saveUser = async () => {
+    const method = editingId ? 'PUT' : 'POST';
+    const res = await fetch('/api/company-users', {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        user_id: editingId,
+        email,
+        password: password || undefined,
+        name,
+        phone,
+        position,
+        company_id: companyId,
+      }),
+    });
+    const data = await res.json();
+    if (data.error) {
+      alert(data.error);
+    } else {
+      if (editingId) {
+        setUsers(users.map((u) => (u.user_id === editingId ? data.user : u)));
+      } else {
+        setUsers([...users, data.user]);
+      }
+      setEditingId(null);
+      setName('');
+      setEmail('');
+      setPhone('');
+      setPassword('');
+      setPosition('');
+    }
+  };
+
+  const startEdit = (u: CompanyUser) => {
+    setEditingId(u.user_id);
+    setName(u.name);
+    setEmail(u.email);
+    setPhone(u.phone);
+    setPosition(u.position || '');
+  };
+
+  const deleteUser = async (user_id: string) => {
+    if (!confirm('Excluir este usuário?')) return;
+    const res = await fetch('/api/company-users', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id, company_id: companyId }),
+    });
+    const data = await res.json();
+    if (data.error) {
+      alert(data.error);
+    } else {
+      setUsers(users.filter((u) => u.user_id !== user_id));
+    }
+  };
+
+  const saveUnit = async () => {
+    const method = unitEditingId ? 'PUT' : 'POST';
+    const res = await fetch('/api/company-units', {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        user_id: unitEditingId,
+        email: uEmail,
+        password: uPassword || undefined,
+        name: uName,
+        phone: uPhone,
+        company_id: companyId,
+      }),
+    });
+    const data = await res.json();
+    if (data.error) {
+      alert(data.error);
+    } else {
+      if (unitEditingId) {
+        setUnits(units.map((u) => (u.user_id === unitEditingId ? data.user : u)));
+      } else {
+        setUnits([...units, data.user]);
+      }
+      setUnitEditingId(null);
+      setUName('');
+      setUEmail('');
+      setUPhone('');
+      setUPassword('');
+    }
+  };
+
+  const startEditUnit = (u: CompanyUnit) => {
+    setUnitEditingId(u.user_id);
+    setUName(u.name);
+    setUEmail(u.email);
+    setUPhone(u.phone);
+  };
+
+  const deleteUnit = async (user_id: string) => {
+    if (!confirm('Excluir esta unidade?')) return;
+    const res = await fetch('/api/company-units', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id, company_id: companyId }),
+    });
+    const data = await res.json();
+    if (data.error) {
+      alert(data.error);
+    } else {
+      setUnits(units.filter((u) => u.user_id !== user_id));
+    }
+  };
+
+  return (
+    <Layout>
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold mb-4">Usuários & Permissões</h1>
+        <div className="mb-4 flex gap-2">
+          <Button variant={tab === 'users' ? 'default' : 'outline'} onClick={() => setTab('users')}>
+            Usuários
+          </Button>
+          <Button variant={tab === 'units' ? 'default' : 'outline'} onClick={() => setTab('units')}>
+            Unidades
+          </Button>
+        </div>
+        {tab === 'users' ? (
+          <>
+            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 mb-4">
+              <Input placeholder="Nome" value={name} onChange={(e) => setName(e.target.value)} />
+              <Input placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+              <Input placeholder="Telefone" value={phone} onChange={(e) => setPhone(e.target.value)} />
+              <Input
+                placeholder="Senha"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+              <div className="flex items-center gap-2">
+                <select
+                  className="border p-2 rounded w-full"
+                  value={position}
+                  onChange={(e) => setPosition(e.target.value)}
+                >
+                  <option value="">Cargo</option>
+                  {positions.map((p) => (
+                    <option key={p} value={p}>
+                      {p}
+                    </option>
+                  ))}
+                </select>
+                <Button type="button" variant="outline" size="sm" onClick={() => setPosOpen(true)}>
+                  Cargos
+                </Button>
+              </div>
+              <div className="sm:col-span-2 lg:col-span-3 flex gap-2">
+                <Button onClick={saveUser} disabled={!name || !email || (!password && !editingId)}>
+                  {editingId ? 'Salvar' : 'Adicionar'}
+                </Button>
+                {editingId && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      setEditingId(null);
+                      setName('');
+                      setEmail('');
+                      setPhone('');
+                      setPassword('');
+                      setPosition('');
+                    }}
+                  >
+                    Cancelar
+                  </Button>
+                )}
+              </div>
+            </div>
+            <table className="w-full text-left border">
+              <thead>
+                <tr className="border-b">
+                  <th className="p-2">Nome</th>
+                  <th className="p-2">Email</th>
+                  <th className="p-2">Telefone</th>
+                  <th className="p-2">Cargo</th>
+                  <th className="p-2">Ações</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((u) => (
+                  <tr key={u.user_id} className="border-b">
+                    <td className="p-2">{u.name}</td>
+                    <td className="p-2">{u.email}</td>
+                    <td className="p-2">{u.phone}</td>
+                    <td className="p-2">{u.position}</td>
+                    <td className="p-2 flex gap-2">
+                      <Button size="sm" variant="outline" onClick={() => startEdit(u)}>
+                        Editar
+                      </Button>
+                      <Button size="sm" variant="destructive" onClick={() => deleteUser(u.user_id)}>
+                        Excluir
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </>
+        ) : (
+          <>
+            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 mb-4">
+              <Input placeholder="Nome" value={uName} onChange={(e) => setUName(e.target.value)} />
+              <Input placeholder="Email" value={uEmail} onChange={(e) => setUEmail(e.target.value)} />
+              <Input placeholder="Telefone" value={uPhone} onChange={(e) => setUPhone(e.target.value)} />
+              <Input
+                placeholder="Senha"
+                type="password"
+                value={uPassword}
+                onChange={(e) => setUPassword(e.target.value)}
+              />
+              <div className="sm:col-span-2 lg:col-span-3 flex gap-2">
+                <Button onClick={saveUnit} disabled={!uName || !uEmail || (!uPassword && !unitEditingId)}>
+                  {unitEditingId ? 'Salvar' : 'Adicionar'}
+                </Button>
+                {unitEditingId && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      setUnitEditingId(null);
+                      setUName('');
+                      setUEmail('');
+                      setUPhone('');
+                      setUPassword('');
+                    }}
+                  >
+                    Cancelar
+                  </Button>
+                )}
+              </div>
+            </div>
+            <table className="w-full text-left border">
+              <thead>
+                <tr className="border-b">
+                  <th className="p-2">Nome</th>
+                  <th className="p-2">Email</th>
+                  <th className="p-2">Telefone</th>
+                  <th className="p-2">Ações</th>
+                </tr>
+              </thead>
+              <tbody>
+                {units.map((u) => (
+                  <tr key={u.user_id} className="border-b">
+                    <td className="p-2">{u.name}</td>
+                    <td className="p-2">{u.email}</td>
+                    <td className="p-2">{u.phone}</td>
+                    <td className="p-2 flex gap-2">
+                      <Button size="sm" variant="outline" onClick={() => startEditUnit(u)}>
+                        Editar
+                      </Button>
+                      <Button size="sm" variant="destructive" onClick={() => deleteUnit(u.user_id)}>
+                        Excluir
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </>
+        )}
+      </div>
+      <PositionSidebar
+        open={posOpen}
+        onClose={() => {
+          setPosOpen(false);
+          supabase
+            .from('positions')
+            .select('name')
+            .eq('company_id', companyId)
+            .then(({ data }) => setPositions(data?.map((p: any) => p.name) || []));
+        }}
+      />
+    </Layout>
+  );
+}

--- a/supabase.sql
+++ b/supabase.sql
@@ -28,6 +28,7 @@ create table public.employees (
   zip text,
   position text,
   department text,
+  unit text,
   salary numeric,
   hire_date date,
   termination_date date,


### PR DESCRIPTION
## Summary
- add sidebar link for user & permission management
- create API route to register company users via Supabase
- build user management page with form and position selector
- enable updating and deleting company users from API and UI
- fix employee creation page hanging by skipping fetch for new record
- add branch management tab and API for company units
- support assigning employees to company units and filtering by branch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1b8095000832d80ba40f5202df39b