### PR TITLE
feat: add company user management

### DIFF
--- a/components/DepartmentSidebar.tsx
+++ b/components/DepartmentSidebar.tsx
@@ -23,16 +23,36 @@ export default function DepartmentSidebar({ open, onClose }: Props) {
     const load = async () => {
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) return;
+      let compId = '';
       const { data: user } = await supabase
         .from('users')
         .select('company_id')
         .eq('id', session.user.id)
-        .single();
-      setCompanyId(user.company_id);
+        .maybeSingle();
+      if (user) {
+        compId = user.company_id;
+      } else {
+        const { data: compUser } = await supabase
+          .from('companies_users')
+          .select('company_id')
+          .eq('user_id', session.user.id)
+          .maybeSingle();
+        if (compUser) {
+          compId = compUser.company_id;
+        } else {
+          const { data: unitUser } = await supabase
+            .from('companies_units')
+            .select('company_id')
+            .eq('user_id', session.user.id)
+            .maybeSingle();
+          compId = unitUser?.company_id || '';
+        }
+      }
+      setCompanyId(compId);
       const { data } = await supabase
         .from('departments')
         .select('*')
-        .eq('company_id', user.company_id);
+        .eq('company_id', compId);
       setDepartments(data || []);
     };
     load();

--- a/components/EmployeeConfigModal.tsx
+++ b/components/EmployeeConfigModal.tsx
@@ -41,12 +41,31 @@ export default function EmployeeConfigModal({ open, onClose }: Props) {
     const load = async () => {
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) return;
+      let compId = '';
       const { data: user } = await supabase
         .from('users')
         .select('company_id')
         .eq('id', session.user.id)
-        .single();
-      const compId = user.company_id;
+        .maybeSingle();
+      if (user) {
+        compId = user.company_id;
+      } else {
+        const { data: compUser } = await supabase
+          .from('companies_users')
+          .select('company_id')
+          .eq('user_id', session.user.id)
+          .maybeSingle();
+        if (compUser) {
+          compId = compUser.company_id;
+        } else {
+          const { data: unitUser } = await supabase
+            .from('companies_units')
+            .select('company_id')
+            .eq('user_id', session.user.id)
+            .maybeSingle();
+          compId = unitUser?.company_id || '';
+        }
+      }
       setCompanyId(compId);
       const { data: deps } = await supabase
         .from('departments')

--- a/components/PositionSidebar.tsx
+++ b/components/PositionSidebar.tsx
@@ -23,16 +23,36 @@ export default function PositionSidebar({ open, onClose }: Props) {
     const load = async () => {
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) return;
+      let compId = '';
       const { data: user } = await supabase
         .from('users')
         .select('company_id')
         .eq('id', session.user.id)
-        .single();
-      setCompanyId(user.company_id);
+        .maybeSingle();
+      if (user) {
+        compId = user.company_id;
+      } else {
+        const { data: compUser } = await supabase
+          .from('companies_users')
+          .select('company_id')
+          .eq('user_id', session.user.id)
+          .maybeSingle();
+        if (compUser) {
+          compId = compUser.company_id;
+        } else {
+          const { data: unitUser } = await supabase
+            .from('companies_units')
+            .select('company_id')
+            .eq('user_id', session.user.id)
+            .maybeSingle();
+          compId = unitUser?.company_id || '';
+        }
+      }
+      setCompanyId(compId);
       const { data } = await supabase
         .from('positions')
         .select('*')
-        .eq('company_id', user.company_id);
+        .eq('company_id', compId);
       setPositions(data || []);
     };
     load();

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -10,6 +10,7 @@ const buttonVariants = cva(
       variant: {
         default: 'bg-brand text-white hover:bg-brand/90',
         outline: 'border border-brand text-brand hover:bg-brand/10',
+        destructive: 'bg-red-500 text-white hover:bg-red-600',
       },
       size: {
         default: 'h-10 px-4 py-2',

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -22,6 +22,7 @@ export const FIELD_LABELS: Record<string, string> = {
   zip: 'CEP',
   position: 'Cargo',
   department: 'Departamento',
+  unit: 'Filial',
   salary: 'Salário',
   hire_date: 'Data de admissão',
   termination_date: 'Data de desligamento',
@@ -47,7 +48,7 @@ export const FIELD_GROUPS = [
   { title: 'Endereço', fields: ['street', 'city', 'state', 'zip'] },
   {
     title: 'Informações profissionais',
-    fields: ['position', 'department', 'salary', 'hire_date', 'status'],
+    fields: ['position', 'department', 'unit', 'salary', 'hire_date', 'status'],
   },
   {
     title: 'Contato de emergência',

--- a/pages/api/company-units.ts
+++ b/pages/api/company-units.ts
@@ -1,0 +1,99 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string;
+
+const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    const { email, password, name, phone, company_id } = req.body;
+
+    const { data: userData, error: authError } = await supabase.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+      user_metadata: { name, phone },
+    });
+
+    if (authError || !userData.user) {
+      return res.status(400).json({ error: authError?.message || 'Erro ao criar usuário' });
+    }
+
+    const userId = userData.user.id;
+
+    const { data: unit, error: insertError } = await supabase
+      .from('companies_units')
+      .insert({ company_id, user_id: userId, name, email, phone })
+      .select('user_id,name,email,phone')
+      .single();
+
+    if (insertError) {
+      return res.status(400).json({ error: insertError.message });
+    }
+
+    return res.status(200).json({ user: unit });
+  }
+
+  if (req.method === 'PUT') {
+    const { user_id, company_id, name, email, phone, password } = req.body;
+
+    const updateAuthPayload: any = {
+      email,
+      user_metadata: { name, phone },
+    };
+
+    if (password) {
+      updateAuthPayload.password = password;
+    }
+
+    const { error: updateAuthError } = await supabase.auth.admin.updateUserById(
+      user_id,
+      updateAuthPayload
+    );
+
+    if (updateAuthError) {
+      return res.status(400).json({ error: updateAuthError.message });
+    }
+
+    const { data: updatedUnit, error: updateError } = await supabase
+      .from('companies_units')
+      .update({ name, email, phone })
+      .eq('company_id', company_id)
+      .eq('user_id', user_id)
+      .select('user_id,name,email,phone')
+      .single();
+
+    if (updateError) {
+      return res.status(400).json({ error: updateError.message });
+    }
+
+    return res.status(200).json({ user: updatedUnit });
+  }
+
+  if (req.method === 'DELETE') {
+    const { user_id, company_id } = req.body;
+
+    const { error: deleteUnitError } = await supabase
+      .from('companies_units')
+      .delete()
+      .eq('company_id', company_id)
+      .eq('user_id', user_id);
+
+    if (deleteUnitError) {
+      return res.status(400).json({ error: deleteUnitError.message });
+    }
+
+    const { error: deleteAuthError } = await supabase.auth.admin.deleteUser(user_id);
+
+    if (deleteAuthError) {
+      return res.status(400).json({ error: deleteAuthError.message });
+    }
+
+    return res.status(200).json({ success: true });
+  }
+
+  res.setHeader('Allow', ['POST', 'PUT', 'DELETE']);
+  return res.status(405).end('Method Not Allowed');
+}

--- a/pages/api/company-users.ts
+++ b/pages/api/company-users.ts
@@ -1,0 +1,99 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string;
+
+const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    const { email, password, name, phone, position, company_id } = req.body;
+
+    const { data: userData, error: authError } = await supabase.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+      user_metadata: { name, phone },
+    });
+
+    if (authError || !userData.user) {
+      return res.status(400).json({ error: authError?.message || 'Erro ao criar usuário' });
+    }
+
+    const userId = userData.user.id;
+
+    const { data: companyUser, error: insertError } = await supabase
+      .from('companies_users')
+      .insert({ company_id, user_id: userId, name, email, phone, position })
+      .select('user_id,name,email,phone,position')
+      .single();
+
+    if (insertError) {
+      return res.status(400).json({ error: insertError.message });
+    }
+
+    return res.status(200).json({ user: companyUser });
+  }
+
+  if (req.method === 'PUT') {
+    const { user_id, company_id, name, email, phone, position, password } = req.body;
+
+    const updateAuthPayload: any = {
+      email,
+      user_metadata: { name, phone },
+    };
+
+    if (password) {
+      updateAuthPayload.password = password;
+    }
+
+    const { error: updateAuthError } = await supabase.auth.admin.updateUserById(
+      user_id,
+      updateAuthPayload
+    );
+
+    if (updateAuthError) {
+      return res.status(400).json({ error: updateAuthError.message });
+    }
+
+    const { data: updatedUser, error: updateError } = await supabase
+      .from('companies_users')
+      .update({ name, email, phone, position })
+      .eq('company_id', company_id)
+      .eq('user_id', user_id)
+      .select('user_id,name,email,phone,position')
+      .single();
+
+    if (updateError) {
+      return res.status(400).json({ error: updateError.message });
+    }
+
+    return res.status(200).json({ user: updatedUser });
+  }
+
+  if (req.method === 'DELETE') {
+    const { user_id, company_id } = req.body;
+
+    const { error: deleteCompanyUserError } = await supabase
+      .from('companies_users')
+      .delete()
+      .eq('company_id', company_id)
+      .eq('user_id', user_id);
+
+    if (deleteCompanyUserError) {
+      return res.status(400).json({ error: deleteCompanyUserError.message });
+    }
+
+    const { error: deleteAuthError } = await supabase.auth.admin.deleteUser(user_id);
+
+    if (deleteAuthError) {
+      return res.status(400).json({ error: deleteAuthError.message });
+    }
+
+    return res.status(200).json({ success: true });
+  }
+
+  res.setHeader('Allow', ['POST', 'PUT', 'DELETE']);
+  return res.status(405).end('Method Not Allowed');
+}

--- a/pages/employees/[id].tsx
+++ b/pages/employees/[id].tsx
@@ -10,7 +10,7 @@ export default function EditEmployee() {
   const [employee, setEmployee] = useState<any>(null);
 
   useEffect(() => {
-    if (!id) return;
+    if (!id || id === 'new') return;
     const load = async () => {
       const { data } = await supabase
         .from('employees')
@@ -22,7 +22,16 @@ export default function EditEmployee() {
     load();
   }, [id]);
 
+  if (id === 'new') {
+    return (
+      <Layout>
+        <EmployeeForm />
+      </Layout>
+    );
+  }
+
   if (!employee) return <p>Carregando...</p>;
+
   return (
     <Layout>
       <EmployeeForm employee={employee} />

--- a/pages/employees/index.tsx
+++ b/pages/employees/index.tsx
@@ -23,7 +23,7 @@ import {
   Trash,
 } from 'lucide-react';
 
-const defaultViewCols = ['name','email','phone','cpf','position','department'];
+const defaultViewCols = ['name','email','phone','cpf','position','department','unit'];
 
 interface Employee {
   id: string;
@@ -48,6 +48,8 @@ export default function Employees() {
   const [views, setViews] = useState<any[]>([]);
   const [currentView, setCurrentView] = useState<any | null>(null);
   const [counts, setCounts] = useState({ active: 0, inactive: 0, dismissed: 0 });
+  const [units, setUnits] = useState<string[]>([]);
+  const [unitFilter, setUnitFilter] = useState('');
   const [field, setField] = useState('');
   const [value, setValue] = useState('');
   const [textValue, setTextValue] = useState('');
@@ -71,6 +73,7 @@ export default function Employees() {
   const [dismissReason, setDismissReason] = useState('');
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [showFilter, setShowFilter] = useState(false);
+  const [allowViewConfig, setAllowViewConfig] = useState(false);
   const router = useRouter();
   const activeEmp = openActions
     ? employees.find((e) => e.id === openActions) || null
@@ -100,24 +103,67 @@ export default function Employees() {
   const load = async () => {
     const { data: { session } } = await supabase.auth.getSession();
     if (!session) return;
+    let companyId = '';
+    let unitName = '';
+    let canConfigViews = false;
     const { data: user } = await supabase
       .from('users')
       .select('company_id')
       .eq('id', session.user.id)
-      .single();
+      .maybeSingle();
+    if (user) {
+      companyId = user.company_id;
+      canConfigViews = true;
+    } else {
+      const { data: compUser } = await supabase
+        .from('companies_users')
+        .select('company_id')
+        .eq('user_id', session.user.id)
+        .maybeSingle();
+      if (compUser) {
+        companyId = compUser.company_id;
+      } else {
+        const { data: unitUser } = await supabase
+          .from('companies_units')
+          .select('company_id,name')
+          .eq('user_id', session.user.id)
+          .maybeSingle();
+        companyId = unitUser?.company_id || '';
+        unitName = unitUser?.name || '';
+        setUnitFilter(unitName);
+      }
+    }
+    if (!companyId) return;
     const { data: defs } = await supabase
       .from('custom_fields')
       .select('field,value')
-      .eq('company_id', user.company_id);
+      .eq('company_id', companyId);
     const defMap: Record<string, string[]> = {};
     defs?.forEach((d: any) => {
       defMap[d.field] = defMap[d.field] ? [...defMap[d.field], d.value] : [d.value];
     });
     setCustomFieldDefs(defMap);
-    const { data = [] } = await supabase
-      .from('employees')
-      .select('*')
-      .eq('company_id', user.company_id);
+    let data: any[] | null = null;
+    if (unitName) {
+      setUnits([]);
+      const res = await supabase
+        .from('employees')
+        .select('*')
+        .eq('company_id', companyId)
+        .eq('unit', unitName);
+      data = res.data || [];
+    } else {
+      const { data: unitRows } = await supabase
+        .from('companies_units')
+        .select('name')
+        .eq('company_id', companyId);
+      setUnits(unitRows?.map((u: any) => u.name) || []);
+      const res = await supabase
+        .from('employees')
+        .select('*')
+        .eq('company_id', companyId);
+      data = res.data || [];
+    }
     const expanded = data.map((emp) => ({ ...emp, ...emp.custom_fields }));
     setEmployees(expanded);
     refreshCounts(expanded);
@@ -126,32 +172,40 @@ export default function Employees() {
       : [];
     const all = Array.from(new Set([...cols, ...Object.keys(defMap)]));
     setAllColumns(all);
-    const { data: viewRows } = await supabase
-      .from('employee_views')
-      .select('*')
-      .eq('user_id', session.user.id)
-      .order('created_at', { ascending: true });
-    let view = viewRows && viewRows.length ? viewRows[0] : null;
-    if (!view) {
-      const { data: created } = await supabase
+    if (canConfigViews) {
+      const { data: viewRows } = await supabase
         .from('employee_views')
-        .insert({
-          user_id: session.user.id,
-          name: 'Principal',
-          columns: defaultViewCols,
-          filters: [],
-        })
-        .select()
-        .single();
-      view = created;
-      setViews([created]);
+        .select('*')
+        .eq('user_id', session.user.id)
+        .order('created_at', { ascending: true });
+      let view = viewRows && viewRows.length ? viewRows[0] : null;
+      if (!view) {
+        const { data: created } = await supabase
+          .from('employee_views')
+          .insert({
+            user_id: session.user.id,
+            name: 'Principal',
+            columns: defaultViewCols,
+            filters: [],
+          })
+          .select()
+          .single();
+        view = created;
+        setViews([created]);
+      } else {
+        setViews(viewRows);
+      }
+      setCurrentView(view);
+      setColumns(view?.columns && view.columns.length ? view.columns : defaultViewCols);
+      setFilters(view?.filters || []);
     } else {
-      setViews(viewRows);
+      setViews([]);
+      setCurrentView(null);
+      setColumns(defaultViewCols);
+      setFilters([]);
     }
-    setCurrentView(view);
-    setColumns(view?.columns && view.columns.length ? view.columns : defaultViewCols);
-    setFilters(view?.filters || []);
     setField(all[0] || '');
+    setAllowViewConfig(canConfigViews);
   };
 
   useEffect(() => {
@@ -324,8 +378,10 @@ export default function Employees() {
     setDeleteId(null);
   };
 
-  const filtered = employees.filter((emp) =>
-    filters.every((f) => {
+  const filtered = employees.filter(
+    (emp) =>
+      (!unitFilter || emp.unit === unitFilter) &&
+      filters.every((f) => {
       const fieldValue = f.custom
         ? emp.custom_fields?.[f.field]
         : emp[f.field];
@@ -456,31 +512,51 @@ export default function Employees() {
         <div className="flex items-center gap-3">
           <Users className="h-5 w-5 text-brand" />
           <h2 className="text-2xl font-semibold">Lista dos funcionários</h2>
-          <select
-            className="border rounded p-1"
-            value={currentView?.id || ''}
-            onChange={(e) => {
-              const v = views.find((view) => view.id === e.target.value);
-              if (v) switchView(v);
-            }}
-          >
-            {views.map((v) => (
-              <option key={v.id} value={v.id}>
-                {v.name}
-              </option>
-            ))}
-          </select>
-          <Button variant="outline" size="sm" onClick={addView}>
-            Nova lista
-          </Button>
-          {currentView && currentView.name !== 'Principal' && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => deleteView(currentView.id)}
+          {allowViewConfig && (
+            <select
+              className="border rounded p-1"
+              value={currentView?.id || ''}
+              onChange={(e) => {
+                const v = views.find((view) => view.id === e.target.value);
+                if (v) switchView(v);
+              }}
             >
-              Excluir
-            </Button>
+              {views.map((v) => (
+                <option key={v.id} value={v.id}>
+                  {v.name}
+                </option>
+              ))}
+            </select>
+          )}
+          {units.length > 0 && (
+            <select
+              className="border rounded p-1"
+              value={unitFilter}
+              onChange={(e) => setUnitFilter(e.target.value)}
+            >
+              <option value="">Todas as filiais</option>
+              {units.map((u) => (
+                <option key={u} value={u}>
+                  {u}
+                </option>
+              ))}
+            </select>
+          )}
+          {allowViewConfig && (
+            <>
+              <Button variant="outline" size="sm" onClick={addView}>
+                Nova lista
+              </Button>
+              {currentView && currentView.name !== 'Principal' && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => deleteView(currentView.id)}
+                >
+                  Excluir
+                </Button>
+              )}
+            </>
           )}
         </div>
         <div className="flex items-center gap-2">

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -22,18 +22,38 @@ export default function Login() {
       return;
     }
     const userId = data.user?.id;
+    let companyId: string | undefined;
     const { data: profile } = await supabase
       .from('users')
       .select('company_id')
       .eq('id', userId)
-      .single();
+      .maybeSingle();
+    if (profile) {
+      companyId = profile.company_id;
+    } else {
+      const { data: compUser } = await supabase
+        .from('companies_users')
+        .select('company_id')
+        .eq('user_id', userId)
+        .maybeSingle();
+      if (compUser) {
+        companyId = compUser.company_id;
+      } else {
+        const { data: unitUser } = await supabase
+          .from('companies_units')
+          .select('company_id')
+          .eq('user_id', userId)
+          .maybeSingle();
+        companyId = unitUser?.company_id;
+      }
+    }
     const { data: company } = await supabase
       .from('companies')
       .select('maxemployees')
-      .eq('id', profile?.company_id)
+      .eq('id', companyId)
       .single();
     if (company?.maxemployees === 0) {
-      router.push(`/pending?companyId=${profile?.company_id}`);
+      router.push(`/pending?companyId=${companyId}`);
     } else {
       router.push('/dashboard');
     }

--- a/pages/users/index.tsx
+++ b/pages/users/index.tsx
@@ -1,0 +1,372 @@
+import { useEffect, useState } from 'react';
+import Layout from '../../components/Layout';
+import { supabase } from '../../lib/supabaseClient';
+import { Input } from '../../components/ui/input';
+import { Button } from '../../components/ui/button';
+import PositionSidebar from '../../components/PositionSidebar';
+
+interface CompanyUser {
+  user_id: string;
+  name: string;
+  email: string;
+  phone: string;
+  position: string | null;
+}
+
+interface CompanyUnit {
+  user_id: string;
+  name: string;
+  email: string;
+  phone: string;
+}
+
+export default function CompanyUsersPage() {
+  const [tab, setTab] = useState<'users' | 'units'>('users');
+  const [users, setUsers] = useState<CompanyUser[]>([]);
+  const [units, setUnits] = useState<CompanyUnit[]>([]);
+  const [companyId, setCompanyId] = useState('');
+  const [positions, setPositions] = useState<string[]>([]);
+  const [posOpen, setPosOpen] = useState(false);
+
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [password, setPassword] = useState('');
+  const [position, setPosition] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const [uName, setUName] = useState('');
+  const [uEmail, setUEmail] = useState('');
+  const [uPhone, setUPhone] = useState('');
+  const [uPassword, setUPassword] = useState('');
+  const [unitEditingId, setUnitEditingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) return;
+      const { data: user } = await supabase
+        .from('users')
+        .select('company_id')
+        .eq('id', session.user.id)
+        .maybeSingle();
+      let compId = '';
+      if (user) {
+        compId = user.company_id;
+      } else {
+        const { data: cu } = await supabase
+          .from('companies_users')
+          .select('company_id')
+          .eq('user_id', session.user.id)
+          .maybeSingle();
+        if (cu) {
+          compId = cu.company_id;
+        } else {
+          const { data: unitUser } = await supabase
+            .from('companies_units')
+            .select('company_id')
+            .eq('user_id', session.user.id)
+            .maybeSingle();
+          compId = unitUser?.company_id || '';
+        }
+      }
+      if (!compId) return;
+      setCompanyId(compId);
+      const { data: posData } = await supabase
+        .from('positions')
+        .select('name')
+        .eq('company_id', compId);
+      setPositions(posData?.map((p: any) => p.name) || []);
+      const { data: companyUsers } = await supabase
+        .from('companies_users')
+        .select('user_id,name,email,phone,position')
+        .eq('company_id', compId);
+      setUsers(companyUsers || []);
+      const { data: companyUnits } = await supabase
+        .from('companies_units')
+        .select('user_id,name,email,phone')
+        .eq('company_id', compId);
+      setUnits(companyUnits || []);
+    };
+    load();
+  }, []);
+
+  const saveUser = async () => {
+    const method = editingId ? 'PUT' : 'POST';
+    const res = await fetch('/api/company-users', {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        user_id: editingId,
+        email,
+        password: password || undefined,
+        name,
+        phone,
+        position,
+        company_id: companyId,
+      }),
+    });
+    const data = await res.json();
+    if (data.error) {
+      alert(data.error);
+    } else {
+      if (editingId) {
+        setUsers(users.map((u) => (u.user_id === editingId ? data.user : u)));
+      } else {
+        setUsers([...users, data.user]);
+      }
+      setEditingId(null);
+      setName('');
+      setEmail('');
+      setPhone('');
+      setPassword('');
+      setPosition('');
+    }
+  };
+
+  const startEdit = (u: CompanyUser) => {
+    setEditingId(u.user_id);
+    setName(u.name);
+    setEmail(u.email);
+    setPhone(u.phone);
+    setPosition(u.position || '');
+  };
+
+  const deleteUser = async (user_id: string) => {
+    if (!confirm('Excluir este usuário?')) return;
+    const res = await fetch('/api/company-users', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id, company_id: companyId }),
+    });
+    const data = await res.json();
+    if (data.error) {
+      alert(data.error);
+    } else {
+      setUsers(users.filter((u) => u.user_id !== user_id));
+    }
+  };
+
+  const saveUnit = async () => {
+    const method = unitEditingId ? 'PUT' : 'POST';
+    const res = await fetch('/api/company-units', {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        user_id: unitEditingId,
+        email: uEmail,
+        password: uPassword || undefined,
+        name: uName,
+        phone: uPhone,
+        company_id: companyId,
+      }),
+    });
+    const data = await res.json();
+    if (data.error) {
+      alert(data.error);
+    } else {
+      if (unitEditingId) {
+        setUnits(units.map((u) => (u.user_id === unitEditingId ? data.user : u)));
+      } else {
+        setUnits([...units, data.user]);
+      }
+      setUnitEditingId(null);
+      setUName('');
+      setUEmail('');
+      setUPhone('');
+      setUPassword('');
+    }
+  };
+
+  const startEditUnit = (u: CompanyUnit) => {
+    setUnitEditingId(u.user_id);
+    setUName(u.name);
+    setUEmail(u.email);
+    setUPhone(u.phone);
+  };
+
+  const deleteUnit = async (user_id: string) => {
+    if (!confirm('Excluir esta unidade?')) return;
+    const res = await fetch('/api/company-units', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id, company_id: companyId }),
+    });
+    const data = await res.json();
+    if (data.error) {
+      alert(data.error);
+    } else {
+      setUnits(units.filter((u) => u.user_id !== user_id));
+    }
+  };
+
+  return (
+    <Layout>
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold mb-4">Usuários & Permissões</h1>
+        <div className="mb-4 flex gap-2">
+          <Button variant={tab === 'users' ? 'default' : 'outline'} onClick={() => setTab('users')}>
+            Usuários
+          </Button>
+          <Button variant={tab === 'units' ? 'default' : 'outline'} onClick={() => setTab('units')}>
+            Unidades
+          </Button>
+        </div>
+        {tab === 'users' ? (
+          <>
+            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 mb-4">
+              <Input placeholder="Nome" value={name} onChange={(e) => setName(e.target.value)} />
+              <Input placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+              <Input placeholder="Telefone" value={phone} onChange={(e) => setPhone(e.target.value)} />
+              <Input
+                placeholder="Senha"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+              <div className="flex items-center gap-2">
+                <select
+                  className="border p-2 rounded w-full"
+                  value={position}
+                  onChange={(e) => setPosition(e.target.value)}
+                >
+                  <option value="">Cargo</option>
+                  {positions.map((p) => (
+                    <option key={p} value={p}>
+                      {p}
+                    </option>
+                  ))}
+                </select>
+                <Button type="button" variant="outline" size="sm" onClick={() => setPosOpen(true)}>
+                  Cargos
+                </Button>
+              </div>
+              <div className="sm:col-span-2 lg:col-span-3 flex gap-2">
+                <Button onClick={saveUser} disabled={!name || !email || (!password && !editingId)}>
+                  {editingId ? 'Salvar' : 'Adicionar'}
+                </Button>
+                {editingId && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      setEditingId(null);
+                      setName('');
+                      setEmail('');
+                      setPhone('');
+                      setPassword('');
+                      setPosition('');
+                    }}
+                  >
+                    Cancelar
+                  </Button>
+                )}
+              </div>
+            </div>
+            <table className="w-full text-left border">
+              <thead>
+                <tr className="border-b">
+                  <th className="p-2">Nome</th>
+                  <th className="p-2">Email</th>
+                  <th className="p-2">Telefone</th>
+                  <th className="p-2">Cargo</th>
+                  <th className="p-2">Ações</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((u) => (
+                  <tr key={u.user_id} className="border-b">
+                    <td className="p-2">{u.name}</td>
+                    <td className="p-2">{u.email}</td>
+                    <td className="p-2">{u.phone}</td>
+                    <td className="p-2">{u.position}</td>
+                    <td className="p-2 flex gap-2">
+                      <Button size="sm" variant="outline" onClick={() => startEdit(u)}>
+                        Editar
+                      </Button>
+                      <Button size="sm" variant="destructive" onClick={() => deleteUser(u.user_id)}>
+                        Excluir
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </>
+        ) : (
+          <>
+            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 mb-4">
+              <Input placeholder="Nome" value={uName} onChange={(e) => setUName(e.target.value)} />
+              <Input placeholder="Email" value={uEmail} onChange={(e) => setUEmail(e.target.value)} />
+              <Input placeholder="Telefone" value={uPhone} onChange={(e) => setUPhone(e.target.value)} />
+              <Input
+                placeholder="Senha"
+                type="password"
+                value={uPassword}
+                onChange={(e) => setUPassword(e.target.value)}
+              />
+              <div className="sm:col-span-2 lg:col-span-3 flex gap-2">
+                <Button onClick={saveUnit} disabled={!uName || !uEmail || (!uPassword && !unitEditingId)}>
+                  {unitEditingId ? 'Salvar' : 'Adicionar'}
+                </Button>
+                {unitEditingId && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      setUnitEditingId(null);
+                      setUName('');
+                      setUEmail('');
+                      setUPhone('');
+                      setUPassword('');
+                    }}
+                  >
+                    Cancelar
+                  </Button>
+                )}
+              </div>
+            </div>
+            <table className="w-full text-left border">
+              <thead>
+                <tr className="border-b">
+                  <th className="p-2">Nome</th>
+                  <th className="p-2">Email</th>
+                  <th className="p-2">Telefone</th>
+                  <th className="p-2">Ações</th>
+                </tr>
+              </thead>
+              <tbody>
+                {units.map((u) => (
+                  <tr key={u.user_id} className="border-b">
+                    <td className="p-2">{u.name}</td>
+                    <td className="p-2">{u.email}</td>
+                    <td className="p-2">{u.phone}</td>
+                    <td className="p-2 flex gap-2">
+                      <Button size="sm" variant="outline" onClick={() => startEditUnit(u)}>
+                        Editar
+                      </Button>
+                      <Button size="sm" variant="destructive" onClick={() => deleteUnit(u.user_id)}>
+                        Excluir
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </>
+        )}
+      </div>
+      <PositionSidebar
+        open={posOpen}
+        onClose={() => {
+          setPosOpen(false);
+          supabase
+            .from('positions')
+            .select('name')
+            .eq('company_id', companyId)
+            .then(({ data }) => setPositions(data?.map((p: any) => p.name) || []));
+        }}
+      />
+    </Layout>
+  );
+}

--- a/supabase.sql
+++ b/supabase.sql
@@ -28,6 +28,7 @@ create table public.employees (
   zip text,
   position text,
   department text,
+  unit text,
   salary numeric,
   hire_date date,
   termination_date date,


### PR DESCRIPTION
## Summary
- add sidebar link for user & permission management
- create API route to register company users via Supabase
- build user management page with form and position selector
- enable updating and deleting company users from API and UI
- fix employee creation page hanging by skipping fetch for new record
- add branch management tab and API for company units
- support assigning employees to company units and filtering by branch
- scope employee data and creation to the logged-in unit
- handle missing user profiles by falling back to company or unit tables and skipping view creation when absent
- scope dashboard metrics to logged-in unit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1b8095000832d80ba40f5202df39b