### PR TITLE
refactor: revert global ui and refine job about tab

### DIFF
--- a/components/StageSidebar.tsx
+++ b/components/StageSidebar.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabaseClient';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+
+interface Stage {
+  id: string;
+  name: string;
+  position: number;
+  sla_days: number | null;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  jobId?: string;
+}
+
+export default function StageSidebar({ open, onClose, jobId }: Props) {
+  const [stages, setStages] = useState<Stage[]>([]);
+  const [companyId, setCompanyId] = useState('');
+  const [name, setName] = useState('');
+  const [sla, setSla] = useState('');
+
+  useEffect(() => {
+    if (!open) return;
+    const load = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) return;
+      const compId =
+        (session.user as any)?.app_metadata?.company_id ||
+        (session.user as any)?.user_metadata?.company_id || '';
+      if (!compId) return;
+      setCompanyId(compId);
+      const query = supabase
+        .from('job_stages')
+        .select('id,name,position,sla_days')
+        .eq('company_id', compId)
+        .order('position');
+      if (jobId) query.eq('job_id', jobId); else query.is('job_id', null);
+      const { data } = await query;
+      setStages(data || []);
+    };
+    load();
+  }, [open]);
+
+  const add = async () => {
+    const { data, error } = await supabase
+      .from('job_stages')
+      .insert({
+        company_id: companyId,
+        job_id: jobId ?? null,
+        name,
+        position: stages.length + 1,
+        sla_days: sla ? Number(sla) : null,
+      })
+      .select('id,name,position,sla_days')
+      .single();
+    if (!error && data) {
+      setStages([...stages, data]);
+      setName('');
+      setSla('');
+    }
+  };
+
+  const save = async (stage: Stage) => {
+    await supabase
+      .from('job_stages')
+      .update({ name: stage.name, position: stage.position, sla_days: stage.sla_days })
+      .eq('id', stage.id);
+  };
+
+  const remove = async (id: string) => {
+    await supabase.from('job_stages').delete().eq('id', id);
+    setStages(stages.filter((s) => s.id !== id));
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 flex justify-end z-50">
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+      <aside className="relative bg-white w-96 h-full p-4 overflow-y-auto shadow-xl">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-semibold">Etapas</h2>
+          <button onClick={onClose}>X</button>
+        </div>
+        <div className="grid grid-cols-3 gap-2 mb-4">
+          <Input
+            placeholder="Nome"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="col-span-2"
+          />
+          <Input
+            placeholder="SLA"
+            type="number"
+            value={sla}
+            onChange={(e) => setSla(e.target.value)}
+          />
+          <div className="col-span-3 flex justify-end">
+            <Button onClick={add} disabled={!name} variant="outline">
+              Adicionar
+            </Button>
+          </div>
+        </div>
+        {stages.map((st) => (
+          <div key={st.id} className="grid grid-cols-6 gap-2 mb-2 items-center">
+            <Input
+              value={st.position}
+              type="number"
+              onChange={(e) => (st.position = Number(e.target.value))}
+              onBlur={() => save(st)}
+              className="col-span-1"
+            />
+            <Input
+              value={st.name}
+              onChange={(e) => (st.name = e.target.value)}
+              onBlur={() => save(st)}
+              className="col-span-3"
+            />
+            <Input
+              value={st.sla_days ?? ''}
+              type="number"
+              onChange={(e) => (st.sla_days = e.target.value ? Number(e.target.value) : null)}
+              onBlur={() => save(st)}
+              className="col-span-1"
+            />
+            <Button variant="outline" size="icon" onClick={() => remove(st.id)}>
+              x
+            </Button>
+          </div>
+        ))}
+      </aside>
+    </div>
+  );
+}
+

--- a/components/TagSidebar.tsx
+++ b/components/TagSidebar.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabaseClient';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { X } from 'lucide-react';
+
+interface Tag {
+  id: string;
+  name: string;
+  color: string;
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  companyId: string;
+}
+
+export default function TagSidebar({ open, onClose, companyId }: Props) {
+  const [tags, setTags] = useState<Tag[]>([]);
+  const [name, setName] = useState('');
+  const [color, setColor] = useState('#a855f7');
+
+  useEffect(() => {
+    if (!open) return;
+    const load = async () => {
+      const { data } = await supabase
+        .from('talent_tags')
+        .select('id,name,color')
+        .eq('company_id', companyId);
+      setTags((data as Tag[]) || []);
+    };
+    load();
+  }, [open, companyId]);
+
+  const add = async () => {
+    const { data, error } = await supabase
+      .from('talent_tags')
+      .insert({ company_id: companyId, name, color })
+      .select('id,name,color')
+      .single();
+    if (!error && data) {
+      setTags([...tags, data as Tag]);
+      setName('');
+    }
+  };
+
+  const save = async (tag: Tag) => {
+    await supabase
+      .from('talent_tags')
+      .update({ name: tag.name, color: tag.color })
+      .eq('id', tag.id);
+  };
+
+  const remove = async (id: string) => {
+    await supabase.from('talent_tags').delete().eq('id', id);
+    setTags(tags.filter((t) => t.id !== id));
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 flex justify-end z-50">
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+      <aside className="relative bg-white w-80 h-full p-4 overflow-y-auto shadow-xl">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-semibold">Tags</h2>
+          <button
+            onClick={onClose}
+            className="p-1 rounded hover:bg-gray-100"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <h3 className="text-sm font-medium mb-2">Adicionar tag</h3>
+        <div className="flex items-center gap-2 mb-4">
+          <Input
+            placeholder="Nome"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="flex-1"
+          />
+          <input
+            type="color"
+            value={color}
+            onChange={(e) => setColor(e.target.value)}
+            className="h-6 w-6 border rounded-full cursor-pointer"
+          />
+          <Button onClick={add} disabled={!name} variant="outline" size="icon">
+            +
+          </Button>
+        </div>
+        {tags.length > 0 && (
+          <h3 className="text-sm font-medium mb-2">Editar tags</h3>
+        )}
+        {tags.map((t) => (
+          <div key={t.id} className="flex items-center gap-2 mb-2">
+            <Input
+              value={t.name}
+              onChange={(e) => (t.name = e.target.value)}
+              onBlur={() => save(t)}
+              className="flex-1"
+            />
+            <input
+              type="color"
+              value={t.color}
+              onChange={(e) => {
+                t.color = e.target.value;
+                setTags([...tags]);
+                save(t);
+              }}
+              className="h-6 w-6 border rounded-full cursor-pointer"
+            />
+            <Button variant="outline" size="icon" onClick={() => remove(t.id)}>
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        ))}
+      </aside>
+    </div>
+  );
+}

--- a/components/recruitment/JobTab.tsx
+++ b/components/recruitment/JobTab.tsx
@@ -1,0 +1,533 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+import { supabase } from '../../lib/supabaseClient';
+import { getJobStatusLabel } from '../../lib/utils';
+import { Card } from '../ui/card';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { X, MoreVertical, Clock } from 'lucide-react';
+
+interface Manager {
+  user_id: string;
+  name: string | null;
+  role?: string | null;
+}
+
+interface Job {
+  id: string;
+  title: string;
+  description: string | null;
+  department: string | null;
+  status: string;
+  manager_id: string | null;
+  created_by: string | null;
+  created_at: string;
+  sla: string | null;
+  company_id: string;
+}
+
+export default function JobTab() {
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [managers, setManagers] = useState<Manager[]>([]);
+  const router = useRouter();
+  const [companyId, setCompanyId] = useState('');
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [department, setDepartment] = useState('');
+  const [status, setStatus] = useState('open');
+  const [managerId, setManagerId] = useState('');
+  const [editing, setEditing] = useState<Job | null>(null);
+  const [open, setOpen] = useState(false);
+  const [view, setView] = useState<'list' | 'cards'>('list');
+  const [sla, setSla] = useState('');
+  const [slaDays, setSlaDays] = useState('');
+  const [menuJob, setMenuJob] = useState<string | null>(null);
+
+  const resetForm = () => {
+    setEditing(null);
+    setTitle('');
+    setDescription('');
+    setDepartment('');
+    setStatus('open');
+    setManagerId('');
+    setSla('');
+    setSlaDays('');
+  };
+
+  const loadJobs = async (compId: string) => {
+    const { data, error } = await supabase
+      .from('jobs')
+      .select('id,title,description,department,status,manager_id,created_by,created_at,sla,company_id')
+      .eq('company_id', compId)
+      .order('created_at', { ascending: false });
+    if (error) {
+      console.error(error);
+      alert(error.message);
+      return;
+    }
+    setJobs(data ?? []);
+  };
+
+  const loadManagers = async (compId: string) => {
+    const { data, error } = await supabase
+      .from('companies_users')
+      .select('user_id,name,role')
+      .eq('company_id', compId)
+      .order('name');
+    if (error) {
+      console.error(error);
+      alert(error.message);
+      return;
+    }
+    setManagers(data ?? []);
+  };
+
+  useEffect(() => {
+    const init = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) return;
+      const compId =
+        (session.user as any)?.user_metadata?.company_id ||
+        (session.user as any)?.app_metadata?.company_id;
+      if (!compId) return;
+      setCompanyId(compId);
+      await loadJobs(compId);
+      await loadManagers(compId);
+    };
+    init();
+  }, []);
+
+  const counts = {
+    open: jobs.filter((j) => j.status === 'open').length,
+    frozen: jobs.filter((j) => j.status === 'frozen').length,
+    closed: jobs.filter((j) => j.status === 'closed').length,
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+
+    if (!session) {
+      alert('Sessão expirada. Faça login novamente.');
+      return;
+    }
+
+    if (!companyId) {
+      alert('Empresa não encontrada.');
+      return;
+    }
+
+    const payload = {
+      title,
+      description: description || null,
+      department: department || null,
+      status,
+      manager_id: managerId || null,
+      sla: sla || null,
+      company_id: companyId,
+    };
+
+    if (editing) {
+      const { error } = await supabase
+        .from('jobs')
+        .update(payload)
+        .eq('id', editing.id);
+      if (error) {
+        console.error(error);
+        alert(error.message);
+        return;
+      }
+      setEditing(null);
+    } else {
+      const { error } = await supabase
+        .from('jobs')
+        .insert({ ...payload, created_by: session.user.id });
+      if (error) {
+        console.error(error);
+        alert(error.message);
+        return;
+      }
+    }
+
+    resetForm();
+    setOpen(false);
+    loadJobs(companyId);
+  };
+
+  const startEdit = (job: Job) => {
+    setEditing(job);
+    setTitle(job.title);
+    setDescription(job.description ?? '');
+    setDepartment(job.department ?? '');
+    setStatus(job.status);
+    setManagerId(job.manager_id ?? '');
+    setSla(job.sla ? job.sla : '');
+    setSlaDays('');
+    setOpen(true);
+  };
+
+  const deleteJob = async (id: string) => {
+    const { error } = await supabase.from('jobs').delete().eq('id', id);
+    if (error) {
+      console.error(error);
+      alert(error.message);
+      return;
+    }
+    loadJobs(companyId);
+  };
+
+  const updateStatus = async (job: Job, newStatus: string) => {
+    const { error } = await supabase
+      .from('jobs')
+      .update({ status: newStatus })
+      .eq('id', job.id);
+    if (error) {
+      console.error(error);
+      alert(error.message);
+      return;
+    }
+    loadJobs(companyId);
+  };
+
+  const duplicateJob = async (job: Job) => {
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    if (!session || !companyId) return;
+    const copy = {
+      title: job.title,
+      description: job.description,
+      department: job.department,
+      status: 'open',
+      manager_id: job.manager_id,
+      created_by: session.user.id,
+      sla: job.sla,
+      company_id: companyId,
+    };
+    const { error } = await supabase.from('jobs').insert(copy);
+    if (error) {
+      console.error(error);
+      alert(error.message);
+      return;
+    }
+    loadJobs(companyId);
+  };
+
+  return (
+    <div>
+      <div className="grid grid-cols-3 gap-4 mb-6">
+        <Card>
+          <p className="text-sm text-gray-500">Abertas</p>
+          <p className="text-2xl font-bold">{counts.open}</p>
+        </Card>
+        <Card>
+          <p className="text-sm text-gray-500">Congeladas</p>
+          <p className="text-2xl font-bold">{counts.frozen}</p>
+        </Card>
+        <Card>
+          <p className="text-sm text-gray-500">Fechadas</p>
+          <p className="text-2xl font-bold">{counts.closed}</p>
+        </Card>
+      </div>
+
+      <div className="flex justify-end gap-2 mb-4">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setView(view === 'list' ? 'cards' : 'list')}
+        >
+          {view === 'list' ? 'Cards' : 'Lista'}
+        </Button>
+        <Button
+          onClick={() => {
+            resetForm();
+            setOpen(true);
+          }}
+        >
+          Criar vaga
+        </Button>
+      </div>
+
+      {open && (
+        <div className="fixed inset-0 flex items-center justify-center z-50">
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => {
+              resetForm();
+              setOpen(false);
+            }}
+          />
+          <div className="relative bg-white rounded-md w-full max-w-lg p-4 shadow-xl dark:bg-gray-900">
+            <button
+              onClick={() => {
+                resetForm();
+                setOpen(false);
+              }}
+              className="absolute top-2 right-2 text-gray-500 hover:text-gray-700"
+            >
+              <X className="h-4 w-4" />
+            </button>
+            <form onSubmit={handleSubmit} className="grid grid-cols-2 gap-2 mt-4">
+              <Input
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Título da vaga"
+                className="col-span-2"
+              />
+              <Input
+                value={department}
+                onChange={(e) => setDepartment(e.target.value)}
+                placeholder="Departamento"
+              />
+              <select
+                className="border rounded-md px-2"
+                value={status}
+                onChange={(e) => setStatus(e.target.value)}
+              >
+                <option value="open">Aberta</option>
+                <option value="frozen">Congelada</option>
+                <option value="closed">Fechada</option>
+              </select>
+              <Input
+                type="date"
+                value={sla}
+                onChange={(e) => setSla(e.target.value)}
+                placeholder="SLA"
+              />
+              <Input
+                type="number"
+                value={slaDays}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  setSlaDays(v);
+                  if (v) {
+                    const d = new Date();
+                    d.setDate(d.getDate() + parseInt(v));
+                    setSla(d.toISOString().split('T')[0]);
+                  }
+                }}
+                placeholder="Dias para fechar"
+              />
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Descrição"
+                className="col-span-2 border rounded-md p-2"
+              />
+              <select
+                className="border rounded-md px-2"
+                value={managerId}
+                onChange={(e) => setManagerId(e.target.value)}
+              >
+                <option value="">Sem gestor</option>
+                {managers
+                  .filter((m) =>
+                    ['admin', 'manager', 'recruiter'].includes(m.role ?? '')
+                  )
+                  .map((m) => (
+                    <option key={m.user_id} value={m.user_id}>
+                      {m.name ?? m.user_id}
+                    </option>
+                  ))}
+              </select>
+              <div className="flex gap-2 justify-end col-span-2">
+                <Button type="submit">{editing ? 'Salvar' : 'Adicionar'}</Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    resetForm();
+                    setOpen(false);
+                  }}
+                >
+                  Cancelar
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {view === 'list' ? (
+        <table className="w-full text-left border-t">
+          <thead>
+            <tr>
+              <th className="py-2">Título</th>
+              <th>Departamento</th>
+              <th>Gestor</th>
+              <th>Criado por</th>
+              <th>SLA</th>
+              <th>Status</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {jobs.map((job) => (
+              <tr key={job.id} className="border-t">
+                <td className="py-2">
+                  <Link href={`/recruitment/jobs/${job.id}`}>{job.title}</Link>
+                </td>
+                <td>{job.department}</td>
+                <td>
+                  {managers.find((m) => m.user_id === job.manager_id)?.name || ''}
+                </td>
+                <td>
+                  {managers.find((m) => m.user_id === job.created_by)?.name || ''}
+                </td>
+                <td>{job.sla || '-'}</td>
+                <td>{getJobStatusLabel(job.status)}</td>
+                <td className="flex gap-2">
+                  {job.status !== 'open' && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => updateStatus(job, 'open')}
+                    >
+                      Ativar
+                    </Button>
+                  )}
+                  <Button size="sm" variant="outline" onClick={() => startEdit(job)}>
+                    Editar
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    onClick={() => deleteJob(job.id)}
+                  >
+                    Excluir
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {jobs.map((job) => {
+            const manager =
+              managers.find((m) => m.user_id === job.manager_id)?.name || '';
+            const daysOpen = Math.floor(
+              (Date.now() - new Date(job.created_at).getTime()) / 86400000
+            );
+            return (
+              <Card key={job.id} className="p-4 relative">
+                <button
+                  className="absolute top-2 right-2"
+                  onClick={() => setMenuJob(menuJob === job.id ? null : job.id)}
+                >
+                  <MoreVertical className="h-4 w-4" />
+                </button>
+                {menuJob === job.id && (
+                  <div className="absolute top-8 right-2 bg-white border rounded shadow-md z-10 w-40 text-sm">
+                    <button
+                      className="block w-full text-left px-4 py-2 hover:bg-gray-100"
+                      onClick={() => {
+                        setMenuJob(null);
+                        router.push(`/recruitment/pipeline?job=${job.id}`);
+                      }}
+                    >
+                      Ver pipeline
+                    </button>
+                    <button
+                      className="block w-full text-left px-4 py-2 hover:bg-gray-100"
+                      onClick={() => {
+                        setMenuJob(null);
+                        router.push(`/recruitment/exports?job=${job.id}`);
+                      }}
+                    >
+                      Exportar candidatos
+                    </button>
+                    <button
+                      className="block w-full text-left px-4 py-2 hover:bg-gray-100"
+                      onClick={() => {
+                        setMenuJob(null);
+                        router.push(`/recruitment/jobs/${job.id}`);
+                      }}
+                    >
+                      Criar divulgação
+                    </button>
+                    {job.status !== 'open' && (
+                      <button
+                        className="block w-full text-left px-4 py-2 hover:bg-gray-100"
+                        onClick={() => {
+                          setMenuJob(null);
+                          updateStatus(job, 'open');
+                        }}
+                      >
+                        Ativar
+                      </button>
+                    )}
+                    {job.status !== 'closed' && (
+                      <button
+                        className="block w-full text-left px-4 py-2 hover:bg-gray-100"
+                        onClick={() => {
+                          setMenuJob(null);
+                          updateStatus(job, 'closed');
+                        }}
+                      >
+                        Fechar
+                      </button>
+                    )}
+                    {job.status !== 'frozen' && (
+                      <button
+                        className="block w-full text-left px-4 py-2 hover:bg-gray-100"
+                        onClick={() => {
+                          setMenuJob(null);
+                          updateStatus(job, 'frozen');
+                        }}
+                      >
+                        Congelar
+                      </button>
+                    )}
+                    <button
+                      className="block w-full text-left px-4 py-2 hover:bg-gray-100"
+                      onClick={() => {
+                        setMenuJob(null);
+                        duplicateJob(job);
+                      }}
+                    >
+                      Duplicar
+                    </button>
+                    <button
+                      className="block w-full text-left px-4 py-2 hover:bg-gray-100 text-red-600"
+                      onClick={() => {
+                        setMenuJob(null);
+                        deleteJob(job.id);
+                      }}
+                    >
+                      Excluir
+                    </button>
+                  </div>
+                )}
+                <div className="pr-6">
+                  <Link
+                    href={`/recruitment/jobs/${job.id}`}
+                    className="font-semibold hover:underline"
+                  >
+                    {job.title}
+                  </Link>
+                  <p className="text-sm text-gray-600">
+                    {job.department || ''} {job.department && manager ? '•' : ''}{' '}
+                    {manager}
+                  </p>
+                  <p className="text-xs text-gray-500 flex items-center">
+                    <Clock className="w-3 h-3 mr-1" />
+                    {daysOpen} dias aberta
+                  </p>
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/components/recruitment/JobTalentBoard.tsx
+++ b/components/recruitment/JobTalentBoard.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../../lib/supabaseClient';
+import { Button } from '../ui/button';
+import StageSidebar from '../StageSidebar';
+import TalentModal from './TalentModal';
+import { getSourceLabel } from '../../lib/utils';
+import { Clock } from 'lucide-react';
+
+interface Stage {
+  id: string;
+  name: string;
+  position: number;
+}
+
+interface Tag {
+  name: string;
+  color: string;
+}
+
+interface ApplicationItem {
+  id: string; // application id
+  talent_id: string;
+  name: string;
+  stage_id: string | null;
+  created_at: string;
+  source: string | null;
+  tags: Tag[];
+}
+
+const DEFAULT_STAGES = [
+  { name: 'Listados', position: 1, sla_days: 2 },
+  { name: 'Triagem Curricular', position: 2, sla_days: 3 },
+  { name: 'Triagem Técnica', position: 3, sla_days: 5 },
+  { name: 'Entrevista Final', position: 4, sla_days: 7 },
+  { name: 'Oferta', position: 5, sla_days: 2 },
+  { name: 'Admitido', position: 6, sla_days: null },
+];
+
+interface Props {
+  jobId: string;
+}
+
+export default function JobTalentBoard({ jobId }: Props) {
+  const [stages, setStages] = useState<Stage[]>([]);
+  const [items, setItems] = useState<ApplicationItem[]>([]);
+  const [dragId, setDragId] = useState<string | null>(null);
+  const [stageOpen, setStageOpen] = useState(false);
+  const [companyId, setCompanyId] = useState('');
+  const [active, setActive] = useState<{
+    talentId: string;
+    appId: string;
+  } | null>(null);
+
+  const load = async () => {
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    if (!session) return;
+    const compId =
+      (session.user as any)?.app_metadata?.company_id ||
+      (session.user as any)?.user_metadata?.company_id || '';
+    if (!compId) return;
+    setCompanyId(compId);
+    let { data: stagesData } = await supabase
+      .from('job_stages')
+      .select('id,name,position')
+      .eq('company_id', compId)
+      .eq('job_id', jobId)
+      .order('position');
+    if (!stagesData || stagesData.length === 0) {
+      const { data } = await supabase
+        .from('job_stages')
+        .insert(
+          DEFAULT_STAGES.map((s) => ({ ...s, company_id: compId, job_id: jobId }))
+        )
+        .select('id,name,position');
+      stagesData = data || [];
+    }
+    setStages(stagesData || []);
+    const { data: appData } = await supabase
+      .from('applications')
+      .select(
+        'id,stage_id,talent:talents(id,name,created_at,source,talent_tag_map(tag:talent_tags(name,color)))'
+      )
+      .eq('company_id', compId)
+      .eq('job_id', jobId);
+    const mapped =
+      appData?.map((a: any) => ({
+        id: a.id,
+        talent_id: a.talent.id,
+        name: a.talent.name,
+        stage_id: a.stage_id,
+        created_at: a.talent.created_at,
+        source: a.talent.source || null,
+        tags:
+          a.talent.talent_tag_map?.map((m: any) => ({
+            name: m.tag.name,
+            color: m.tag.color || '#a855f7',
+          })) || [],
+      })) || [];
+    setItems(mapped);
+  };
+
+  useEffect(() => {
+    load();
+  }, [jobId]);
+
+  const onDrop = async (stageId: string) => {
+    if (!dragId) return;
+    console.log('[JobTalentBoard] updating application', {
+      id: dragId,
+      stage: stageId,
+    });
+    const { data, error } = await supabase
+      .from('applications')
+      .update({ stage_id: stageId })
+      .eq('id', dragId)
+      .select();
+    if (error) {
+      console.error('[JobTalentBoard] update failed', error);
+      alert(error.message);
+    } else {
+      console.log('[JobTalentBoard] update success', data);
+      setItems((prev) =>
+        prev.map((t) => (t.id === dragId ? { ...t, stage_id: stageId } : t)),
+      );
+    }
+    setDragId(null);
+  };
+
+  const timeSince = (date: string) => {
+    const diff = Date.now() - new Date(date).getTime();
+    const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+    if (days > 0) return `${days}d`;
+    const hours = Math.floor(diff / (1000 * 60 * 60));
+    return `${hours}h`;
+  };
+
+  const grouped = stages.map((s) => ({
+    stage: s,
+    items: items.filter((t) => t.stage_id === s.id),
+  }));
+
+  return (
+    <div>
+      <div className="mb-4 flex justify-between">
+        <h2 className="text-xl font-semibold">Talentos</h2>
+        <Button variant="outline" onClick={() => setStageOpen(true)}>
+          Etapas
+        </Button>
+      </div>
+      <div className="flex gap-4 overflow-x-auto">
+        {grouped.map(({ stage, items }) => (
+          <div
+            key={stage.id}
+            className="w-64 bg-gray-100 rounded p-2"
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={() => onDrop(stage.id)}
+          >
+            <h3 className="font-medium mb-2">{stage.name}</h3>
+            {items.map((t) => (
+              <div
+                key={t.id}
+                className="bg-white rounded shadow p-2 mb-2 cursor-move"
+                draggable
+                onDragStart={() => setDragId(t.id)}
+              >
+                <div className="flex justify-between text-xs text-gray-500">
+                  <span className="flex items-center">
+                    <Clock className="w-3 h-3 mr-1" />
+                    {timeSince(t.created_at)}
+                  </span>
+                  {t.source && <span>{getSourceLabel(t.source)}</span>}
+                </div>
+                <button
+                  className="mt-1 block font-medium hover:underline text-left"
+                  onClick={() =>
+                    setActive({ talentId: t.talent_id, appId: t.id })
+                  }
+                >
+                  {t.name}
+                </button>
+                {t.tags.length > 0 && (
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {(() => {
+                      const MAX = 2;
+                      const shown = t.tags.slice(0, MAX);
+                      const extra = t.tags.length - shown.length;
+                      return (
+                        <>
+                          {shown.map((tag) => (
+                            <span
+                              key={tag.name}
+                              className="px-2 py-0.5 rounded text-xs"
+                              style={{
+                                color: tag.color,
+                                backgroundColor: `${tag.color}33`,
+                                fontWeight: 'bold',
+                              }}
+                            >
+                              {tag.name}
+                            </span>
+                          ))}
+                          {extra > 0 && (
+                            <span className="px-2 py-0.5 rounded bg-gray-200 text-xs">+{extra}</span>
+                          )}
+                        </>
+                      );
+                    })()}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+      {active && (
+        <TalentModal
+          talentId={active.talentId}
+          applicationId={active.appId}
+          companyId={companyId}
+          onClose={() => {
+            setActive(null);
+            load();
+          }}
+        />
+      )}
+      <StageSidebar
+        open={stageOpen}
+        onClose={() => {
+          setStageOpen(false);
+          load();
+        }}
+        jobId={jobId}
+      />
+    </div>
+  );
+}

--- a/components/recruitment/TalentModal.tsx
+++ b/components/recruitment/TalentModal.tsx
@@ -1,0 +1,341 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../../lib/supabaseClient';
+import { Button } from '../ui/button';
+import { X, Settings } from 'lucide-react';
+import TagSidebar from '../TagSidebar';
+
+interface Tag {
+  name: string;
+  color: string;
+}
+
+interface Props {
+  talentId: string;
+  applicationId: string;
+  companyId: string;
+  onClose: () => void;
+}
+
+export default function TalentModal({ talentId, applicationId, companyId, onClose }: Props) {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [city, setCity] = useState('');
+  const [state, setState] = useState('');
+  const [cvUrl, setCvUrl] = useState('');
+  const [salary, setSalary] = useState('');
+  const [seniority, setSeniority] = useState('');
+  const [availability, setAvailability] = useState('');
+  const [source, setSource] = useState('');
+  const [comment, setComment] = useState('');
+  const [tags, setTags] = useState<Tag[]>([]);
+  const [newTag, setNewTag] = useState('');
+  const [newColor, setNewColor] = useState('#a855f7');
+  const [suggestions, setSuggestions] = useState<Tag[]>([]);
+  const [tagOpen, setTagOpen] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      const { data: talent } = await supabase
+        .from('talents')
+        .select(
+          'name,email,phone,city,state,cv_url,salary_expectation,seniority,availability,source,comment,talent_tag_map(tag:talent_tags(name,color))'
+        )
+        .eq('id', talentId)
+        .single();
+      if (talent) {
+        setName(talent.name);
+        setEmail(talent.email);
+        setPhone(talent.phone || '');
+        setCity(talent.city || '');
+        setState(talent.state || '');
+        setCvUrl(talent.cv_url || '');
+        setSalary(talent.salary_expectation?.toString() || '');
+        setSeniority(talent.seniority || '');
+        setAvailability(talent.availability || '');
+        setSource(talent.source || '');
+        setComment(talent.comment || '');
+        setTags(
+          talent.talent_tag_map?.map((m: any) => ({
+            name: m.tag.name,
+            color: m.tag.color || '#a855f7',
+          })) || []
+        );
+      }
+    };
+    if (talentId) load();
+  }, [talentId]);
+
+  const refreshTags = async () => {
+    const { data } = await supabase
+      .from('talent_tags')
+      .select('name,color')
+      .eq('company_id', companyId);
+    const list = (data as Tag[]) || [];
+    setSuggestions(list);
+    setTags((prev) =>
+      prev.map((t) => {
+        const found = list.find((s) => s.name === t.name);
+        return found ? { ...t, color: found.color } : t;
+      })
+    );
+  };
+
+  useEffect(() => {
+    if (companyId) refreshTags();
+  }, [companyId]);
+
+  const handleTagClose = () => {
+    setTagOpen(false);
+    refreshTags();
+  };
+
+  const addTag = () => {
+    const t = newTag.trim();
+    if (!t) return;
+    const existing = suggestions.find((s) => s.name === t);
+    const color = existing ? existing.color : newColor;
+    if (!tags.find((tag) => tag.name === t)) {
+      setTags([...tags, { name: t, color }]);
+    }
+    setNewTag('');
+    setNewColor('#a855f7');
+  };
+
+  const removeTag = (name: string) =>
+    setTags(tags.filter((tag) => tag.name !== name));
+
+  const save = async () => {
+    const { error: tError } = await supabase
+      .from('talents')
+      .update({
+        name,
+        email,
+        phone,
+        city,
+        state,
+        cv_url: cvUrl,
+        salary_expectation: salary ? Number(salary) : null,
+        seniority,
+        availability,
+        source,
+        comment,
+      })
+      .eq('id', talentId);
+    if (tError) {
+      console.error(tError);
+      alert(tError.message);
+      return;
+    }
+    const { data: existing } = await supabase
+      .from('talent_tags')
+      .select('id,name,color')
+      .eq('company_id', companyId);
+    const tagIds: string[] = [];
+    for (const tag of tags) {
+      const found = existing?.find((e: any) => e.name === tag.name);
+      if (found) {
+        tagIds.push(found.id);
+        if (found.color !== tag.color) {
+          await supabase
+            .from('talent_tags')
+            .update({ color: tag.color })
+            .eq('id', found.id);
+        }
+      } else {
+        const { data: inserted } = await supabase
+          .from('talent_tags')
+          .insert({ company_id: companyId, name: tag.name, color: tag.color })
+          .select('id')
+          .single();
+        if (inserted) tagIds.push(inserted.id);
+      }
+    }
+    await supabase.from('talent_tag_map').delete().eq('talent_id', talentId);
+    if (tagIds.length) {
+      await supabase
+        .from('talent_tag_map')
+        .insert(tagIds.map((id) => ({ talent_id: talentId, tag_id: id })));
+    }
+    onClose();
+  };
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-40">
+        <div className="bg-white rounded p-4 w-full max-w-lg max-h-[80vh] overflow-y-auto">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-xl font-bold">Talento</h2>
+          <button onClick={onClose} className="p-1 rounded hover:bg-gray-100">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2 mb-4">
+          <div className="sm:col-span-2">
+            <label className="block text-sm font-medium mb-1">Nome</label>
+            <input
+              className="w-full border p-2 rounded"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Email</label>
+            <input
+              className="w-full border p-2 rounded"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Telefone</label>
+            <input
+              className="w-full border p-2 rounded"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Cidade</label>
+            <input
+              className="w-full border p-2 rounded"
+              value={city}
+              onChange={(e) => setCity(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Estado</label>
+            <input
+              className="w-full border p-2 rounded"
+              value={state}
+              onChange={(e) => setState(e.target.value)}
+            />
+          </div>
+          <div className="sm:col-span-2">
+            <label className="block text-sm font-medium mb-1">URL do currículo</label>
+            <input
+              className="w-full border p-2 rounded"
+              value={cvUrl}
+              onChange={(e) => setCvUrl(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Pretensão salarial</label>
+            <input
+              type="number"
+              className="w-full border p-2 rounded"
+              value={salary}
+              onChange={(e) => setSalary(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Senioridade</label>
+            <input
+              className="w-full border p-2 rounded"
+              value={seniority}
+              onChange={(e) => setSeniority(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Disponibilidade</label>
+            <input
+              className="w-full border p-2 rounded"
+              value={availability}
+              onChange={(e) => setAvailability(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Fonte</label>
+            <select
+              className="w-full border p-2 rounded appearance-none pr-6"
+              value={source}
+              onChange={(e) => setSource(e.target.value)}
+            >
+              <option value="">Selecione</option>
+              <option value="career_site">Site</option>
+              <option value="referral">Indicação</option>
+              <option value="linkedin">LinkedIn</option>
+              <option value="import">Importação</option>
+              <option value="event">Evento</option>
+              <option value="other">Outro</option>
+            </select>
+          </div>
+          <div className="sm:col-span-2">
+            <div className="flex items-center justify-between mb-1">
+              <div className="font-medium">Tags</div>
+              <Button type="button" variant="outline" size="icon" onClick={() => setTagOpen(true)}>
+                <Settings className="h-4 w-4" />
+              </Button>
+            </div>
+            <div className="flex flex-wrap gap-2 mb-2">
+              {tags.map((t) => (
+                <span
+                  key={t.name}
+                  className="px-2 py-1 rounded text-xs flex items-center gap-1"
+                  style={{
+                    color: t.color,
+                    backgroundColor: `${t.color}33`,
+                    fontWeight: 'bold',
+                  }}
+                >
+                  {t.name}
+                  <button onClick={() => removeTag(t.name)}>×</button>
+                </span>
+              ))}
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="flex-1">
+                <input
+                  className="w-full border p-2 rounded appearance-none"
+                  placeholder="Adicionar tag"
+                  value={newTag}
+                  list="tag-suggestions"
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    setNewTag(val);
+                    const found = suggestions.find((s) => s.name === val);
+                    setNewColor(found?.color || '#a855f7');
+                  }}
+                />
+              </div>
+              <datalist id="tag-suggestions">
+                {suggestions.map((s) => (
+                  <option key={s.name} value={s.name} />
+                ))}
+              </datalist>
+              <input
+                type="color"
+                className="h-6 w-6 border rounded-full cursor-pointer"
+                value={newColor}
+                onChange={(e) => setNewColor(e.target.value)}
+              />
+              <Button type="button" size="sm" onClick={addTag}>
+                Adicionar
+              </Button>
+            </div>
+          </div>
+          <div className="sm:col-span-2">
+            <label className="block text-sm font-medium mb-1">Observações</label>
+            <textarea
+              className="w-full border p-2 rounded"
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+            />
+          </div>
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={onClose}>
+            Cancelar
+          </Button>
+          <Button onClick={save}>Salvar</Button>
+        </div>
+        </div>
+      </div>
+      <TagSidebar
+        open={tagOpen}
+        onClose={handleTagClose}
+        companyId={companyId}
+      />
+    </>
+  );
+}

--- a/components/recruitment/TalentTab.tsx
+++ b/components/recruitment/TalentTab.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../../lib/supabaseClient';
+import { Button } from '../ui/button';
+import StageSidebar from '../StageSidebar';
+
+interface Stage {
+  id: string;
+  name: string;
+  position: number;
+}
+
+interface Talent {
+  id: string;
+  name: string;
+  stage_id: string | null;
+}
+
+const DEFAULT_STAGES = [
+  { name: 'Listados', position: 1, sla_days: 2 },
+  { name: 'Triagem Curricular', position: 2, sla_days: 3 },
+  { name: 'Triagem Técnica', position: 3, sla_days: 5 },
+  { name: 'Entrevista Final', position: 4, sla_days: 7 },
+  { name: 'Oferta', position: 5, sla_days: 2 },
+  { name: 'Admitido', position: 6, sla_days: null },
+];
+
+export default function TalentTab() {
+  const [stages, setStages] = useState<Stage[]>([]);
+  const [talents, setTalents] = useState<Talent[]>([]);
+  const [dragId, setDragId] = useState<string | null>(null);
+  const [stageOpen, setStageOpen] = useState(false);
+  const [companyId, setCompanyId] = useState('');
+
+  const load = async () => {
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    if (!session) return;
+    const compId =
+      (session.user as any)?.app_metadata?.company_id ||
+      (session.user as any)?.user_metadata?.company_id || '';
+    if (!compId) return;
+    setCompanyId(compId);
+    let { data: stagesData } = await supabase
+      .from('job_stages')
+      .select('id,name,position')
+      .eq('company_id', compId)
+      .is('job_id', null)
+      .order('position');
+    if (!stagesData || stagesData.length === 0) {
+      const { data } = await supabase
+        .from('job_stages')
+        .insert(
+          DEFAULT_STAGES.map((s) => ({ ...s, company_id: compId }))
+        )
+        .select('id,name,position');
+      stagesData = data || [];
+    }
+    setStages(stagesData || []);
+    const { data: talentsData } = await supabase
+      .from('talents')
+      .select('id,name,stage_id')
+      .eq('company_id', compId);
+    setTalents(talentsData || []);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const onDrop = async (stageId: string) => {
+    if (!dragId) return;
+    await supabase.from('talents').update({ stage_id: stageId }).eq('id', dragId);
+    setTalents((prev) => prev.map((t) => (t.id === dragId ? { ...t, stage_id: stageId } : t)));
+    setDragId(null);
+  };
+
+  const grouped = stages.map((s) => ({
+    stage: s,
+    items: talents.filter((t) => t.stage_id === s.id),
+  }));
+
+  return (
+    <div>
+      <div className="mb-4 flex justify-between">
+        <h2 className="text-xl font-semibold">Banco de Talentos</h2>
+        <Button variant="outline" onClick={() => setStageOpen(true)}>
+          Etapas
+        </Button>
+      </div>
+      <div className="flex gap-4 overflow-x-auto">
+        {grouped.map(({ stage, items }) => (
+          <div
+            key={stage.id}
+            className="w-64 bg-gray-100 rounded p-2"
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={() => onDrop(stage.id)}
+          >
+            <h3 className="font-medium mb-2">{stage.name}</h3>
+            {items.map((talent) => (
+              <div
+                key={talent.id}
+                className="bg-white rounded shadow p-2 mb-2 cursor-move"
+                draggable
+                onDragStart={() => setDragId(talent.id)}
+              >
+                {talent.name}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+      <StageSidebar
+        open={stageOpen}
+        onClose={() => {
+          setStageOpen(false);
+          load();
+        }}
+      />
+    </div>
+  );
+}
+

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,70 @@
+import React, { createContext, useContext, useState } from 'react';
+import { cn } from '../../lib/utils';
+
+interface TabsContextValue {
+  value: string;
+  setValue: (value: string) => void;
+}
+
+const TabsContext = createContext<TabsContextValue | undefined>(undefined);
+
+export function Tabs({
+  defaultValue,
+  children,
+}: {
+  defaultValue: string;
+  children: React.ReactNode;
+}) {
+  const [value, setValue] = useState(defaultValue);
+  return (
+    <TabsContext.Provider value={{ value, setValue }}>
+      {children}
+    </TabsContext.Provider>
+  );
+}
+
+export function TabsList({
+  className,
+  children,
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn('flex border-b border-gray-200', className)}>
+      {children}
+    </div>
+  );
+}
+
+export function TabsTrigger({
+  value,
+  children,
+}: {
+  value: string;
+  children: React.ReactNode;
+}) {
+  const ctx = useContext(TabsContext);
+  const active = ctx?.value === value;
+  return (
+    <button
+      onClick={() => ctx?.setValue(value)}
+      className={cn(
+        'px-4 py-2 text-sm font-medium',
+        active ? 'border-b-2 border-brand text-brand' : 'text-gray-500'
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function TabsContent({
+  value,
+  children,
+}: {
+  value: string;
+  children: React.ReactNode;
+}) {
+  const ctx = useContext(TabsContext);
+  if (ctx?.value !== value) return null;
+  return <div className="mt-4">{children}</div>;
+}
+

--- a/docs/recruitment-selection-ui.md
+++ b/docs/recruitment-selection-ui.md
@@ -1,0 +1,85 @@
+# Recrutamento & Seleção (R&S) - Especificação de UI
+
+Esta especificação descreve a interface do módulo de Recrutamento & Seleção. O objetivo é orientar a implementação de telas, componentes e comportamentos seguindo o design system existente e garantindo acessibilidade.
+
+## Navegação
+- **Sidebar principal**: entrada "Recrutamento & Seleção" abre submódulos.
+- **Topbar fixa**: links para **Vagas**, **Banco de Talentos**, **Pipeline Global**, **Relatórios**, **Exportações** e **Configurações**.
+- Header com busca global, filtros rápidos (empresa/área/período), avatar, notificações.
+
+## Ações e Componentes Globais
+- Ações padrão em cada página: **Novo**, **Filtrar**, **Salvar visão**, **Exportar**, **Colunas**, **Ações em lote**.
+- Componentes base: Cards, DataTable com paginação infinita, Drawer/Modal, Sheet lateral, Tabs, Empty States, Toaster.
+- Paleta de badges: vaga → Aberta (verde), Congelada (amarelo), Fechada (cinza); candidatura → Ativo (azul), Reprovado (vermelho), Desistente (cinza); SLA → No prazo (verde), Atenção (amarelo), Estourado (vermelho).
+- Acessibilidade AA: foco visível, navegação por teclado, labels descritivos e feedback em `aria-live`.
+
+## 1. Vagas (`/jobs`)
+### Lista de Vagas
+- Topo com botões: Nova Vaga, Filtrar, Salvar visão, Colunas, Exportar.
+- Busca por título, área e gestor.
+- Tabela com colunas: Título (link), Área, Gestor, Status, Candidatos Ativos, Dias em aberto, Criada em, Última atividade, Ações.
+- Drawer de filtros: status, área, local, senioridade, gestor, período. Filtros persistem via querystring. Colunas configuráveis por usuário.
+- Visões salvas: “Minhas vagas”, “Abertas”, “Congeladas”, “Fechadas”.
+- Ações em lote: Fechar, Congelar, Duplicar vaga.
+- Empty state com CTA “Criar primeira vaga”.
+
+### Detalhe da Vaga (`/jobs/:id`)
+- Layout em tabs: **Visão Geral**, **Talentos**, **Analytics**, **Divulgação**, **Configurações**.
+- Visão Geral: cards de Status, Dias em aberto, Gestor, Etapas do pipeline, Candidatos por etapa, timeline de atividades, botões Editar, Fechar, Congelar, Duplicar.
+- Talentos: tabela ou Kanban com etapas da vaga. Cards mostram nome, cargo/pretensão, dias na etapa, SLA, origem, anexos/notas. Drag‑and‑drop move estágio; reprovar/desistir exige motivo.
+- Analytics: funil da vaga, KPIs de conversão, origem, reprovação e SLA.
+- Divulgação: formulário de anúncio, link público e QR code, campos configuráveis e pré-filtros automáticos.
+- Configurações: etapas customizadas, SLA por etapa, permissões e responsáveis padrão.
+
+## 2. Banco de Talentos (`/talents`)
+### Lista
+- Topo com: Novo Talento, Importar CSV/Excel, Filtrar, Salvar visão, Colunas, Exportar.
+- Busca global por nome, email, telefone.
+- Colunas: Nome, Email, Telefone, Localização, Senioridade, Skills, Tags, Origem, Último movimento, Status geral, Ações.
+- Filtros facetados: localização, skills, tags, senioridade, origem, disponibilidade, “em processo”.
+- Ações em lote: adicionar tags, marcar contatado, encaminhar para vaga.
+- Importação com staging/preview de erros e detecção de duplicados.
+
+### Perfil do Talento (`/talents/:id`)
+- Coluna esquerda: identificação, contatos, localização, card profissional (cargo, senioridade, pretensão, disponibilidade), skills/tags, anexos, consentimento LGPD.
+- Coluna direita: histórico em vagas, notas internas, ações (encaminhar para vaga, marcar contatado, adicionar observação).
+- Encaminhar cria application com etapa inicial e responsável.
+
+## 3. Pipeline Global (`/pipeline`)
+- Filtros no topo: vaga, área, gestor, período, origem, etapa, tags; busca por nome.
+- Botões: Agrupar por (Etapa | Vaga | Responsável), Densidade (compacto/normal), Exportar.
+- Kanban com colunas por etapa ou agrupamento escolhido; cards exibem nome, vaga, dias na etapa, SLA badge, origem, responsável, ícones de anexo/nota.
+- Drag‑and‑drop com validações; mover para Reprovado/Desistente exige motivo.
+- Sheet lateral de candidato com ações rápidas (Mover, Reprovar, Desistir, Trocar responsável, Perfil).
+
+## 4. Relatórios (`/reports`)
+- Filtros persistentes: período, vaga, área, origem, responsável.
+- Cards KPI: Time to Fill, Taxa de Conversão, Origem principal, % dentro do SLA, Motivo de reprovação mais comum.
+- Gráficos: funil de contratação, tempo médio por etapa, origem de candidatos, motivos de reprovação.
+- Exportar CSV ou PDF; click em cards aplica drill‑down nos filtros.
+
+## 5. Exportações (`/exports`)
+- Seletor de dataset: Vagas, Talentos, Candidaturas, Eventos, Métricas agregadas.
+- Seleção de colunas e filtros; prévia com primeiras linhas. Botões para Exportar CSV/Excel e Agendar exportação. Histórico de exportações recentes.
+
+## 6. Configurações (`/settings/recruiting`)
+- CRUD de etapas padrão do processo, SLA por etapa, motivos padronizados, origens, tags e skills.
+- Permissões: papéis, escopos e máscara de PII para `viewer`.
+- Integrações opcionais (email, WhatsApp, webhooks).
+
+## 7. Microcopy
+- Exemplos prontos para modais de reprovação, desistência e mensagens de SLA.
+
+## 8. Estados e Validações
+- Empty states com CTA, feedback de sucesso/erro via toast, confirmações em ações destrutivas, validação de duplicidade de talentos e badges de consentimento LGPD.
+
+## 9. Observabilidade & Telemetria
+- Eventos de uso: `jobs.view_list`, `talents.create`, `applications.move_stage`, `pipeline.view`, `reports.export_pdf`, etc., com company_id, user_id, filtros ativos, latency_ms e resultado.
+
+## 10. Critérios de Aceite Gerais
+- Filtros e colunas persistem por usuário/visão.
+- Kanban com drag‑and‑drop fluido e auditoria.
+- SLA visível nos cards.
+- Perfis de talento com histórico completo e anexos.
+- Relatórios e exportações refletem exatamente o estado filtrado.
+- Acessibilidade básica garantida.

--- a/docs/recruitment-selection.md
+++ b/docs/recruitment-selection.md
@@ -1,0 +1,286 @@
+# Recrutamento & Seleção (R&S) - Arquitetura e Schema
+
+## 1. Visão Geral
+O módulo de R&S centraliza talentos, vagas e candidaturas em uma base multitenant.
+Principais objetivos:
+- Manter um **Banco de Talentos global** com histórico completo.
+- Acompanhar candidaturas em um **Pipeline global** com etapas configuráveis.
+- Gerar **relatórios e exportações** com KPIs de contratação.
+- Garantir **segurança** e conformidade com **LGPD** via RLS e auditoria.
+
+## 2. Arquitetura de Domínio
+### Entidades Principais
+- **talents**: candidatos independentes de vaga.
+- **talent_tags**, **talent_tag_map**: taxonomia flexível de tags.
+- **skills**, **talent_skill_map**: habilidades técnicas ou comportamentais.
+- **jobs**: vagas com status e etapas personalizadas.
+- **job_stages**: etapas padrão por empresa ou sobrescritas por vaga.
+- **applications**: vínculo talento↔vaga com estágio atual.
+- **application_stage_history**: histórico de mudanças de etapa e SLAs.
+- **application_events**: auditoria de ações (quem, quando, payload).
+- **reports_cache**: materialização periódica de métricas.
+
+### Relacionamentos
+- `talents.company_id -> companies.id`
+- `jobs.company_id -> companies.id`
+- `applications.job_id -> jobs.id`
+- `applications.talent_id -> talents.id`
+- `job_stages.job_id -> jobs.id` (ou nulo para padrão da empresa)
+- `application_stage_history.application_id -> applications.id`
+- `application_events.application_id -> applications.id`
+
+## 3. Script SQL (Supabase)
+```sql
+-- Enums
+create type recruitment_role as enum ('admin','recruiter','manager','viewer');
+create type job_status as enum ('open','closed','frozen');
+create type application_stage as enum ('applied','screening','interview','offer','admitted','rejected','withdrawn');
+create type candidate_source as enum ('career_site','referral','linkedin','import','event','other');
+create type rejection_reason as enum ('lack_of_skill','cultural_fit','salary','position_filled','candidate_withdrew','other');
+
+-- Talents
+create table talents (
+  id uuid primary key default uuid_generate_v4(),
+  company_id uuid not null references companies(id) on delete cascade,
+  name text not null,
+  email text not null,
+  phone text,
+  city text,
+  state text,
+  comment text,
+  links jsonb default '[]',
+  cv_url text,
+  salary_expectation numeric,
+  seniority text,
+  availability text,
+  source candidate_source,
+  consent_at timestamptz,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  unique (company_id, email),
+  unique (company_id, phone)
+);
+comment on table talents is 'Banco de talentos global';
+
+create table talent_tags (
+  id uuid primary key default uuid_generate_v4(),
+  company_id uuid not null references companies(id) on delete cascade,
+  name text not null,
+  color text,
+  unique (company_id, name)
+);
+create table talent_tag_map (
+  talent_id uuid references talents(id) on delete cascade,
+  tag_id uuid references talent_tags(id) on delete cascade,
+  primary key (talent_id, tag_id)
+);
+
+create table skills (
+  id uuid primary key default uuid_generate_v4(),
+  company_id uuid not null references companies(id) on delete cascade,
+  name text not null,
+  unique (company_id, name)
+);
+create table talent_skill_map (
+  talent_id uuid references talents(id) on delete cascade,
+  skill_id uuid references skills(id) on delete cascade,
+  primary key (talent_id, skill_id)
+);
+
+-- Jobs
+create table jobs (
+  id uuid primary key default uuid_generate_v4(),
+  company_id uuid not null references companies(id) on delete cascade,
+  title text not null,
+  description text,
+  department text,
+  manager_id uuid references companies_users(user_id),
+  status job_status default 'open',
+  opened_at date default current_date,
+  closed_at date,
+  created_at timestamptz default now(),
+  created_by uuid references auth.users(id)
+);
+comment on table jobs is 'Vagas de recrutamento';
+
+create table job_stages (
+  id uuid primary key default uuid_generate_v4(),
+  company_id uuid not null references companies(id) on delete cascade,
+  job_id uuid references jobs(id) on delete cascade,
+  name text not null,
+  position int not null,
+  sla_days int,
+  unique (job_id, position)
+);
+
+-- Applications
+create table applications (
+  id uuid primary key default uuid_generate_v4(),
+  company_id uuid not null references companies(id) on delete cascade,
+  job_id uuid not null references jobs(id) on delete cascade,
+  talent_id uuid not null references talents(id) on delete cascade,
+  current_stage application_stage default 'applied',
+  status application_stage default 'applied',
+  applied_at timestamptz default now(),
+  source candidate_source,
+  notes text,
+  unique (job_id, talent_id)
+);
+
+create table application_stage_history (
+  id uuid primary key default uuid_generate_v4(),
+  application_id uuid not null references applications(id) on delete cascade,
+  from_stage application_stage,
+  to_stage application_stage not null,
+  moved_at timestamptz default now(),
+  moved_by uuid references auth.users(id),
+  reason rejection_reason,
+  note text,
+  due_at timestamptz,
+  breached_at timestamptz
+);
+
+create table application_events (
+  id uuid primary key default uuid_generate_v4(),
+  company_id uuid not null references companies(id) on delete cascade,
+  application_id uuid references applications(id) on delete cascade,
+  event_type text not null,
+  payload jsonb not null default '{}',
+  created_at timestamptz default now(),
+  created_by uuid references auth.users(id)
+);
+comment on table application_events is 'Auditoria de ações do pipeline';
+
+create table reports_cache (
+  company_id uuid not null references companies(id) on delete cascade,
+  period_start date not null,
+  period_end date not null,
+  metric text not null,
+  value numeric not null,
+  primary key (company_id, metric, period_start, period_end)
+);
+```
+
+### RLS Básico
+```sql
+-- Exemplo para talents
+alter table talents enable row level security;
+
+create policy "talents_select" on talents
+for select using (company_id = auth.jwt() ->> 'company_id');
+
+create policy "talents_modify" on talents
+for insert with check (auth.jwt() ->> 'company_role' in ('admin','recruiter','manager')
+                      and company_id = auth.jwt() ->> 'company_id')
+  to authenticated;
+
+create policy "talents_update" on talents
+for update using (auth.jwt() ->> 'company_role' in ('admin','recruiter','manager')
+                  and company_id = auth.jwt() ->> 'company_id')
+  with check (company_id = auth.jwt() ->> 'company_id');
+
+create policy "talents_delete" on talents
+for delete using (auth.jwt() ->> 'company_role' = 'admin'
+                  and company_id = auth.jwt() ->> 'company_id');
+```
+Políticas similares devem ser aplicadas às demais tabelas, sempre filtrando por `company_id` e papel (`company_role`).
+
+## 4. Fluxos Principais
+1. **Cadastro de Talento**
+   - Manual: recrutador preenche campos básicos e confirma consentimento.
+   - Importação: arquivo CSV/Excel processado em `staging_talents`, validações e upsert.
+   - Formulário público da vaga: candidato envia dados; sistema verifica duplicidade por email/telefone.
+2. **Criação de Vaga**
+   - Admin define título, requisitos, gestor e etapas.
+   - Etapas herdadas do padrão da empresa podem ser ajustadas por vaga.
+3. **Inscrição do Candidato**
+   - Link público gera registro em `applications` e vincula talento.
+   - Verifica duplicidade; histórico consolidado no talento.
+4. **Movimentação no Pipeline**
+   - Mudança de etapa cria registro em `application_stage_history` e evento.
+   - Reprovações/desistências exigem motivo (`rejection_reason`).
+   - SLA: `due_at` calculado a partir de `sla_days`; se `now() > due_at` e sem movimentação, marca `breached_at` e dispara alerta.
+5. **Encerramento de Vaga**
+   - `status` passa para `closed`; `closed_at` definido pelo primeiro `application` admitido.
+   - KPIs como Time to Fill são atualizados em `reports_cache`.
+6. **Exportação/Relatórios**
+   - Usuário seleciona filtros e colunas; serviço gera CSV/Excel ou PDF com KPIs e gráficos.
+
+## 5. Regras de Negócio
+- **Etapas**: empresa define etapas padrão; vagas podem sobrescrever ou adicionar etapas.
+- **SLA**: armazenar `due_at` por etapa e marcar `breached_at` ao ultrapassar o prazo.
+- **Duplicidade de Talentos**: busca por email/telefone; se duplicado, mescla dados preservando histórico.
+- **LGPD**: campo `consent_at`; opção de anonimização que substitui PII por valores nulos mantendo métricas.
+- **Permissões**:
+  - `admin`: total acesso.
+  - `manager`: gerencia vagas próprias e lê todas.
+  - `recruiter`: cria talentos e move candidaturas.
+  - `viewer`: leitura com mascaramento de email/telefone.
+
+## 6. KPIs
+- **Time to Fill**: `jobs.date_filled - jobs.opened_at`.
+- **Conversão por etapa**: `COUNT(history.to_stage = B)/COUNT(history.from_stage = A)`.
+- **Origem de candidatos**: `COUNT(*) GROUP BY applications.source`.
+- **Motivos de reprovação**: `COUNT(*) GROUP BY history.reason`.
+- **SLA cumprido**: `COUNT(history.breached_at IS NULL)/COUNT(*)` por etapa.
+Exemplos de consulta encontram-se no relatório agregando `application_stage_history`.
+
+## 7. Importação e Exportação
+- **Importação**: arquivos enviados vão para `staging_talents` com validação de headers; registros válidos movidos para `talents` via upsert.
+- **Exportação**: serviço constrói consultas dinâmicas respeitando filtros e colunas selecionadas; saída em CSV/Excel e PDF com KPIs.
+
+## 8. Integrações e Automações
+- **Webhooks**: `application_events` dispara webhooks para mudanças de etapa e SLA violado.
+- **Cron Jobs**: recalculam `reports_cache` e processam importações em lote.
+- **Endpoint público**: `/apply/{job_id}` com rate limit e captcha.
+
+## 9. Segurança e LGPD
+- RLS em todas as tabelas restringindo por `company_id` e papel.
+- Máscara de PII para `viewer` via view ou retorno parcial.
+- Auditoria completa em `application_events`.
+- `consent_at` rastreia consentimento; anonimização atende pedidos de "esquecer meus dados".
+
+## 10. Glossário de Eventos
+- `talent.created`
+- `job.created`
+- `application.created`
+- `application.stage_moved`
+- `application.rejected`
+- `application.sla_breached`
+- `job.closed`
+Cada evento grava `company_id`, `application_id` (quando aplicável), `event_type`, `payload`, `created_at`, `created_by`.
+
+## 11. Exemplos de KPIs (SQL)
+```sql
+-- Time to Fill por vaga
+select j.id, j.title,
+       j.closed_at - j.opened_at as time_to_fill
+from jobs j
+where j.status = 'closed';
+
+-- Conversão inscrito -> entrevista
+select count(*) filter (where to_stage = 'interview')::numeric /
+       nullif(count(*) filter (where from_stage = 'applied'),0) as conv_applied_to_interview
+from application_stage_history
+where company_id = auth.jwt() ->> 'company_id';
+
+-- SLA cumprido por etapa
+select to_stage,
+       count(*) filter (where breached_at is null)::numeric / count(*) as pct_on_time
+from application_stage_history
+where company_id = auth.jwt() ->> 'company_id'
+group by to_stage;
+```
+
+## 12. Plano de Importação/Exportação
+- **Staging**: `staging_talents` (mesma estrutura de `talents` + coluna `errors` jsonb).
+- **Validação**: função PL/pgSQL verifica obrigatórios, normaliza dados e grava erros.
+- **Deduplicação**: `on conflict (company_id,email)` atualiza registros preservando histórico.
+- **Export**: função gera `COPY (query) TO STDOUT WITH CSV` ou usa biblioteca de Excel/PDF no backend.
+
+## 13. Guia de Segurança/LGPD
+- Consentimento obrigatório (`consent_at`).
+- Anonimização: atualização de PII para `null` e preservação de campos analíticos.
+- Logs de acesso e manipulação em `application_events`.
+- Retenção: políticas para expurgo de talentos inativos após X anos.
+```

--- a/pages/recruitment/index.tsx
+++ b/pages/recruitment/index.tsx
@@ -1,0 +1,48 @@
+import Head from 'next/head';
+import Layout from '../../components/Layout';
+import JobTab from '../../components/recruitment/JobTab';
+import TalentTab from '../../components/recruitment/TalentTab';
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from '../../components/ui/tabs';
+
+export default function Recruitment() {
+  return (
+    <>
+      <Head>
+        <title>Recrutamento & Seleção</title>
+      </Head>
+      <Layout>
+        <h1 className="text-2xl font-bold mb-4">Recrutamento & Seleção</h1>
+        <Tabs defaultValue="jobs">
+          <TabsList className="mb-4">
+            <TabsTrigger value="jobs">Vagas</TabsTrigger>
+            <TabsTrigger value="talents">Banco de Talentos</TabsTrigger>
+            <TabsTrigger value="pipeline">Pipeline Global</TabsTrigger>
+            <TabsTrigger value="reports">Relatórios</TabsTrigger>
+            <TabsTrigger value="exports">Exportações</TabsTrigger>
+          </TabsList>
+          <TabsContent value="jobs">
+            <JobTab />
+          </TabsContent>
+          <TabsContent value="talents">
+            <TalentTab />
+          </TabsContent>
+          <TabsContent value="pipeline">
+            <p>Pipeline Global em construção.</p>
+          </TabsContent>
+          <TabsContent value="reports">
+            <p>Relatórios em construção.</p>
+          </TabsContent>
+          <TabsContent value="exports">
+            <p>Exportações em construção.</p>
+          </TabsContent>
+        </Tabs>
+      </Layout>
+    </>
+  );
+}
+

--- a/pages/recruitment/jobs/[id].tsx
+++ b/pages/recruitment/jobs/[id].tsx
@@ -1,0 +1,626 @@
+import { useRouter } from 'next/router';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import Layout from '../../../components/Layout';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '../../../components/ui/tabs';
+import JobTalentBoard from '../../../components/recruitment/JobTalentBoard';
+import { supabase } from '../../../lib/supabaseClient';
+import { Input } from '../../../components/ui/input';
+import { Button } from '../../../components/ui/button';
+import { Card } from '../../../components/ui/card';
+import { getSourceLabel } from '../../../lib/utils';
+import { Plus, X } from 'lucide-react';
+
+interface Job {
+  id: string;
+  company_id: string;
+  title: string;
+  department: string | null;
+  manager_id: string | null;
+  status: string;
+  opened_at: string | null;
+  sla: string | null;
+  work_location: string | null;
+  summary: string | null;
+  responsibilities: string[] | null;
+  requirements: string[] | null;
+  desirables: string[] | null;
+  salary_range: string | null;
+  benefits: string | null;
+  contract_type: string | null;
+  workload: string | null;
+  seniority: string | null;
+  form_fields: string[] | null;
+}
+
+export default function JobDetails() {
+  const router = useRouter();
+  const { id } = router.query;
+  const [job, setJob] = useState<Job | null>(null);
+  const [fields, setFields] = useState<string[]>([]);
+  const [managers, setManagers] = useState<{ user_id: string; name: string }[]>([]);
+  const [candidateCount, setCandidateCount] = useState(0);
+  const [sourceDist, setSourceDist] = useState<Record<string, number>>({});
+  const [workMode, setWorkMode] = useState<'remote' | 'onsite' | 'hybrid'>('remote');
+  const [salaryMin, setSalaryMin] = useState('');
+  const [salaryMax, setSalaryMax] = useState('');
+  const [contractOptions, setContractOptions] = useState<string[]>([
+    'CLT',
+    'PJ',
+    'Estágio',
+    'Trainee',
+    'Menor Aprendiz',
+  ]);
+  const [newContract, setNewContract] = useState('');
+  const [showMsg, setShowMsg] = useState(false);
+
+  useEffect(() => {
+    if (!id || Array.isArray(id)) return;
+    supabase
+      .from('jobs')
+      .select(
+        'id,company_id,title,department,manager_id,status,opened_at,sla,work_location,summary,responsibilities,requirements,desirables,salary_range,benefits,contract_type,workload,seniority,form_fields'
+      )
+      .eq('id', id)
+      .maybeSingle()
+      .then(async ({ data }) => {
+        if (data) {
+          const jobData = data as Job;
+          if (jobData.work_location) {
+            if (jobData.work_location === 'remote') {
+              setWorkMode('remote');
+              jobData.work_location = '';
+            } else if (jobData.work_location.includes('|')) {
+              const [mode, addr] = jobData.work_location.split('|');
+              setWorkMode(mode as 'remote' | 'onsite' | 'hybrid');
+              jobData.work_location = addr;
+            }
+          }
+          if (jobData.salary_range) {
+            const [min, max] = jobData.salary_range.split('-');
+            setSalaryMin(min || '');
+            setSalaryMax(max || '');
+          }
+          if (jobData.workload) {
+            const m = jobData.workload.match(/\d+/);
+            jobData.workload = m ? m[0] : jobData.workload;
+          }
+          setJob(jobData);
+          setFields((data.form_fields as string[]) || ['name', 'email']);
+          const { data: mgrs } = await supabase
+            .from('companies_users')
+            .select('user_id,name')
+            .eq('company_id', data.company_id);
+          setManagers(mgrs || []);
+          const { data: apps } = await supabase
+            .from('applications')
+            .select('source')
+            .eq('job_id', id);
+          if (apps) {
+            setCandidateCount(apps.length);
+            const dist: Record<string, number> = {};
+            apps.forEach((a) => {
+              const key = a.source || 'other';
+              dist[key] = (dist[key] || 0) + 1;
+            });
+            setSourceDist(dist);
+          }
+        }
+      });
+  }, [id]);
+
+  const talentFields = [
+    { id: 'name', label: 'Nome' },
+    { id: 'email', label: 'Email' },
+    { id: 'phone', label: 'Telefone' },
+    { id: 'city', label: 'Cidade' },
+    { id: 'state', label: 'Estado' },
+    { id: 'cv_url', label: 'Currículo URL' },
+    { id: 'salary_expectation', label: 'Pretensão salarial' },
+    { id: 'seniority', label: 'Senioridade' },
+    { id: 'availability', label: 'Disponibilidade' },
+  ];
+
+  const saveFields = async () => {
+    if (!id || Array.isArray(id)) return;
+    const { error } = await supabase
+      .from('jobs')
+      .update({ form_fields: fields })
+      .eq('id', id);
+    if (error) {
+      console.error(error);
+      alert(error.message);
+    }
+  };
+
+  const publicLink =
+    typeof window !== 'undefined' && id
+      ? `${window.location.origin}/apply/${id}`
+      : '';
+
+  return (
+    <>
+      <Head>
+        <title>{job ? job.title : 'Vaga'} - Recrutamento</title>
+      </Head>
+      <Layout>
+        <Link href="/recruitment" className="text-sm text-blue-600 hover:underline">
+          &larr; Voltar para Vagas
+        </Link>
+        <h1 className="text-2xl font-bold mt-2 mb-4">{job?.title || 'Vaga'}</h1>
+        <Tabs defaultValue="talents">
+          <TabsList className="mb-4">
+            <TabsTrigger value="talents">Talentos</TabsTrigger>
+            <TabsTrigger value="about">Sobre a vaga</TabsTrigger>
+            <TabsTrigger value="metrics">Métricas</TabsTrigger>
+            <TabsTrigger value="ads">Divulgação</TabsTrigger>
+            <TabsTrigger value="settings">Roteiro</TabsTrigger>
+          </TabsList>
+          <TabsContent value="talents">
+            {id && !Array.isArray(id) && <JobTalentBoard jobId={id} />}
+          </TabsContent>
+          <TabsContent value="about">
+            {job && (
+              <div className="space-y-4">
+                <Card className="p-4 space-y-2">
+                  <h2 className="font-medium">Informações principais</h2>
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    <div>
+                      <label className="text-sm">Título</label>
+                      <Input
+                        value={job.title}
+                        onChange={(e) => setJob({ ...job, title: e.target.value })}
+                      />
+                    </div>
+                    <div>
+                      <label className="text-sm">Departamento</label>
+                      <Input
+                        value={job.department || ''}
+                        onChange={(e) => setJob({ ...job, department: e.target.value })}
+                      />
+                    </div>
+                    <div>
+                      <label className="text-sm">Gestor responsável</label>
+                      <select
+                        className="border p-2 rounded w-full"
+                        value={job.manager_id || ''}
+                        onChange={(e) => setJob({ ...job, manager_id: e.target.value })}
+                      >
+                        <option value="">--</option>
+                        {managers.map((m) => (
+                          <option key={m.user_id} value={m.user_id}>
+                            {m.name}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label className="text-sm">Status</label>
+                      <select
+                        className="border p-2 rounded w-full"
+                        value={job.status}
+                        onChange={(e) => setJob({ ...job, status: e.target.value })}
+                      >
+                        <option value="open">Aberta</option>
+                        <option value="frozen">Congelada</option>
+                        <option value="closed">Fechada</option>
+                      </select>
+                    </div>
+                    <div>
+                      <label className="text-sm">Data de abertura</label>
+                      <Input
+                        type="date"
+                        value={job.opened_at || ''}
+                        onChange={(e) => setJob({ ...job, opened_at: e.target.value })}
+                      />
+                    </div>
+                    <div>
+                      <label className="text-sm">Prazo estimado</label>
+                      <div className="flex items-center gap-2">
+                        <Input
+                          type="date"
+                          value={job.sla || ''}
+                          onChange={(e) => setJob({ ...job, sla: e.target.value })}
+                        />
+                        {job.opened_at && job.sla && (
+                          <span className="text-sm text-gray-600">
+                            {Math.ceil(
+                              (new Date(job.sla).getTime() -
+                                new Date(job.opened_at).getTime()) /
+                                (1000 * 60 * 60 * 24)
+                            )}{' '}
+                            dias
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <div className="sm:col-span-2">
+                      <label className="text-sm">Local de trabalho</label>
+                      <div className="flex flex-col gap-2">
+                        <div className="flex gap-2">
+                          {[
+                            { id: 'onsite', label: 'Presencial' },
+                            { id: 'remote', label: 'Home Office' },
+                            { id: 'hybrid', label: 'Híbrido' },
+                          ].map((opt) => (
+                            <label key={opt.id} className="flex items-center gap-1">
+                              <input
+                                type="radio"
+                                name="workmode"
+                                value={opt.id}
+                                checked={workMode === opt.id}
+                                onChange={() => setWorkMode(opt.id as any)}
+                              />
+                              {opt.label}
+                            </label>
+                          ))}
+                        </div>
+                        {workMode !== 'remote' && (
+                          <Input
+                            placeholder="Endereço"
+                            value={job.work_location || ''}
+                            onChange={(e) => setJob({ ...job, work_location: e.target.value })}
+                          />
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </Card>
+
+                <Card className="p-4 space-y-2">
+                  <h2 className="font-medium">Descrição da oportunidade</h2>
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    <div className="sm:col-span-2">
+                      <label className="text-sm">Resumo</label>
+                      <textarea
+                        className="w-full border rounded p-2"
+                        rows={3}
+                        value={job.summary || ''}
+                        onChange={(e) => setJob({ ...job, summary: e.target.value })}
+                      />
+                    </div>
+                    <div className="sm:col-span-2">
+                      <label className="text-sm">Responsabilidades principais</label>
+                      {(job.responsibilities || []).map((r, i) => (
+                        <div key={i} className="flex gap-2 mb-1">
+                          <Input
+                            value={r}
+                            onChange={(e) => {
+                              const arr = [...(job.responsibilities || [])];
+                              arr[i] = e.target.value;
+                              setJob({ ...job, responsibilities: arr });
+                            }}
+                          />
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="icon"
+                            onClick={() => {
+                              const arr = [...(job.responsibilities || [])];
+                              arr.splice(i, 1);
+                              setJob({ ...job, responsibilities: arr });
+                            }}
+                          >
+                            <X className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      ))}
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() =>
+                          setJob({
+                            ...job,
+                            responsibilities: [...(job.responsibilities || []), ''],
+                          })
+                        }
+                      >
+                        <Plus className="h-4 w-4" />
+                      </Button>
+                    </div>
+                    <div className="sm:col-span-2">
+                      <label className="text-sm">Requisitos obrigatórios</label>
+                      {(job.requirements || []).map((r, i) => (
+                        <div key={i} className="flex gap-2 mb-1">
+                          <Input
+                            value={r}
+                            onChange={(e) => {
+                              const arr = [...(job.requirements || [])];
+                              arr[i] = e.target.value;
+                              setJob({ ...job, requirements: arr });
+                            }}
+                          />
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="icon"
+                            onClick={() => {
+                              const arr = [...(job.requirements || [])];
+                              arr.splice(i, 1);
+                              setJob({ ...job, requirements: arr });
+                            }}
+                          >
+                            <X className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      ))}
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() =>
+                          setJob({
+                            ...job,
+                            requirements: [...(job.requirements || []), ''],
+                          })
+                        }
+                      >
+                        <Plus className="h-4 w-4" />
+                      </Button>
+                    </div>
+                    <div className="sm:col-span-2">
+                      <label className="text-sm">Diferenciais desejáveis</label>
+                      {(job.desirables || []).map((r, i) => (
+                        <div key={i} className="flex gap-2 mb-1">
+                          <Input
+                            value={r}
+                            onChange={(e) => {
+                              const arr = [...(job.desirables || [])];
+                              arr[i] = e.target.value;
+                              setJob({ ...job, desirables: arr });
+                            }}
+                          />
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="icon"
+                            onClick={() => {
+                              const arr = [...(job.desirables || [])];
+                              arr.splice(i, 1);
+                              setJob({ ...job, desirables: arr });
+                            }}
+                          >
+                            <X className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      ))}
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() =>
+                          setJob({
+                            ...job,
+                            desirables: [...(job.desirables || []), ''],
+                          })
+                        }
+                      >
+                        <Plus className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                </Card>
+
+                <Card className="p-4 space-y-2">
+                  <h2 className="font-medium">Informações estratégicas</h2>
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    <div>
+                      <label className="text-sm">Faixa salarial</label>
+                      <div className="flex gap-2">
+                        <Input
+                          placeholder="Mínimo"
+                          value={salaryMin}
+                          onChange={(e) => setSalaryMin(e.target.value)}
+                        />
+                        <Input
+                          placeholder="Máximo"
+                          value={salaryMax}
+                          onChange={(e) => setSalaryMax(e.target.value)}
+                        />
+                      </div>
+                    </div>
+                    <div>
+                      <label className="text-sm">Tipo de contrato</label>
+                      <div className="flex flex-col gap-2">
+                        <div className="flex flex-wrap gap-2">
+                          {contractOptions.map((opt) => (
+                            <div
+                              key={opt}
+                              className={`flex items-center gap-1 border rounded px-2 py-1 text-sm ${
+                                job.contract_type === opt
+                                  ? 'bg-blue-600 text-white'
+                                  : ''
+                              }`}
+                            >
+                              <button
+                                type="button"
+                                onClick={() => setJob({ ...job, contract_type: opt })}
+                              >
+                                {opt}
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  setContractOptions(
+                                    contractOptions.filter((o) => o !== opt)
+                                  )
+                                }
+                              >
+                                <X className="h-3 w-3" />
+                              </button>
+                            </div>
+                          ))}
+                        </div>
+                        <div className="flex gap-2">
+                          <Input
+                            placeholder="Adicionar tipo"
+                            value={newContract}
+                            onChange={(e) => setNewContract(e.target.value)}
+                          />
+                          <Button
+                            type="button"
+                            onClick={() => {
+                              if (!newContract) return;
+                              setContractOptions([...contractOptions, newContract]);
+                              setNewContract('');
+                            }}
+                          >
+                            <Plus className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      </div>
+                    </div>
+                    <div>
+                      <label className="text-sm">Carga horária</label>
+                      <div className="flex items-center gap-2">
+                        <Input
+                          type="number"
+                          value={job.workload || ''}
+                          onChange={(e) => setJob({ ...job, workload: e.target.value })}
+                        />
+                        <span className="text-sm">horas semanais</span>
+                      </div>
+                    </div>
+                    <div>
+                      <label className="text-sm">Nível de senioridade</label>
+                      <select
+                        className="border p-2 rounded w-full"
+                        value={job.seniority || ''}
+                        onChange={(e) => setJob({ ...job, seniority: e.target.value })}
+                      >
+                        <option value="">--</option>
+                        <option value="junior">Junior</option>
+                        <option value="pleno">Pleno</option>
+                        <option value="senior">Senior</option>
+                        <option value="especialista">Especialista</option>
+                      </select>
+                    </div>
+                    <div className="sm:col-span-2">
+                      <label className="text-sm">Benefícios</label>
+                      <textarea
+                        className="w-full border rounded p-2"
+                        rows={3}
+                        value={job.benefits || ''}
+                        onChange={(e) => setJob({ ...job, benefits: e.target.value })}
+                      />
+                    </div>
+                  </div>
+                </Card>
+
+                <Card className="p-4 space-y-2">
+                  <h2 className="font-medium">Insights da vaga</h2>
+                  <p>Quantidade de candidatos inscritos: {candidateCount}</p>
+                  <ul className="list-disc list-inside">
+                    {Object.entries(sourceDist).map(([src, count]) => (
+                      <li key={src}>
+                        {getSourceLabel(src)}: {count}
+                      </li>
+                    ))}
+                  </ul>
+                </Card>
+
+                <Button
+                  onClick={async () => {
+                    if (!id || Array.isArray(id) || !job) return;
+                    const payload = {
+                      title: job.title,
+                      department: job.department,
+                      manager_id: job.manager_id,
+                      status: job.status,
+                      opened_at: job.opened_at,
+                      sla: job.sla,
+                      work_location:
+                        workMode === 'remote'
+                          ? 'remote'
+                          : `${workMode}|${job.work_location || ''}`,
+                      summary: job.summary,
+                      responsibilities: job.responsibilities,
+                      requirements: job.requirements,
+                      desirables: job.desirables,
+                      salary_range:
+                        salaryMin || salaryMax
+                          ? `${salaryMin}-${salaryMax}`
+                          : null,
+                      benefits: job.benefits,
+                      contract_type: job.contract_type,
+                      workload: job.workload
+                        ? `${job.workload} horas semanais`
+                        : null,
+                      seniority: job.seniority,
+                    };
+                    const { error } = await supabase
+                      .from('jobs')
+                      .update(payload)
+                      .eq('id', id);
+                    if (error) {
+                      console.error(error);
+                      alert(error.message);
+                    } else {
+                      setShowMsg(true);
+                      setTimeout(() => setShowMsg(false), 3000);
+                    }
+                  }}
+                >
+                  Salvar
+                </Button>
+                {showMsg && (
+                  <div className="fixed top-4 right-4 bg-green-100 border border-green-400 text-green-800 px-4 py-2 rounded">
+                    Alterações salvas com sucesso
+                  </div>
+                )}
+              </div>
+            )}
+          </TabsContent>
+          <TabsContent value="metrics">
+            <p>Métricas em construção.</p>
+          </TabsContent>
+          <TabsContent value="ads">
+            <div className="space-y-4">
+              <div>
+                <p className="font-medium mb-2">Campos do formulário público</p>
+                {talentFields.map((f) => (
+                  <label key={f.id} className="flex items-center gap-2 mb-1">
+                    <input
+                      type="checkbox"
+                      checked={fields.includes(f.id)}
+                      onChange={(e) => {
+                        setFields(
+                          e.target.checked
+                            ? [...fields, f.id]
+                            : fields.filter((x) => x !== f.id)
+                        );
+                      }}
+                    />
+                    {f.label}
+                  </label>
+                ))}
+                <button
+                  onClick={saveFields}
+                  className="mt-2 px-4 py-2 bg-blue-600 text-white rounded"
+                >
+                  Salvar
+                </button>
+              </div>
+              {publicLink && (
+                <div>
+                  <p className="font-medium">Link público da vaga</p>
+                  <input
+                    readOnly
+                    value={publicLink}
+                    className="w-full border p-2 rounded"
+                    onFocus={(e) => e.target.select()}
+                  />
+                </div>
+              )}
+            </div>
+          </TabsContent>
+          <TabsContent value="settings">
+            <p>Roteiro em construção.</p>
+          </TabsContent>
+        </Tabs>
+      </Layout>
+    </>
+  );
+}

--- a/supabaserecrutamento.sql
+++ b/supabaserecrutamento.sql
@@ -1,0 +1,189 @@
+-- Recrutamento & Seleção Supabase schema
+
+-- Extensions
+create extension if not exists "uuid-ossp";
+
+-- Enums
+create type recruitment_role as enum ('admin','recruiter','manager','viewer');
+create type job_status as enum ('open','closed','frozen');
+create type application_status as enum ('applied','screening','interview','offer','admitted','rejected','withdrawn');
+create type candidate_source as enum ('career_site','referral','linkedin','import','event','other');
+create type rejection_reason as enum ('lack_of_skill','cultural_fit','salary','position_filled','candidate_withdrew','other');
+
+-- Talents
+create table if not exists talents (
+  id uuid primary key default uuid_generate_v4(),
+  company_id uuid not null references companies(id) on delete cascade,
+  name text not null,
+  email text not null,
+  phone text,
+  city text,
+  state text,
+  comment text,
+  stage_id uuid references job_stages(id),
+  links jsonb default '[]',
+  cv_url text,
+  salary_expectation numeric,
+  seniority text,
+  availability text,
+  source candidate_source,
+  consent_at timestamptz,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  unique (company_id,email),
+  unique (company_id,phone)
+);
+comment on table talents is 'Banco de talentos global';
+
+create table if not exists talent_tags (
+  id uuid primary key default uuid_generate_v4(),
+  company_id uuid not null references companies(id) on delete cascade,
+  name text not null,
+  color text,
+  unique (company_id,name)
+);
+
+create table if not exists talent_tag_map (
+  talent_id uuid references talents(id) on delete cascade,
+  tag_id uuid references talent_tags(id) on delete cascade,
+  primary key (talent_id,tag_id)
+);
+
+create table if not exists skills (
+  id uuid primary key default uuid_generate_v4(),
+  company_id uuid not null references companies(id) on delete cascade,
+  name text not null,
+  unique (company_id,name)
+);
+
+create table if not exists talent_skill_map (
+  talent_id uuid references talents(id) on delete cascade,
+  skill_id uuid references skills(id) on delete cascade,
+  primary key (talent_id,skill_id)
+);
+
+-- Jobs
+create table if not exists jobs (
+  id uuid primary key default uuid_generate_v4(),
+  company_id uuid not null references companies(id) on delete cascade,
+  title text not null,
+  description text,
+  department text,
+  manager_id uuid,
+  status job_status default 'open',
+  opened_at date default current_date,
+  closed_at date,
+  sla date,
+  work_location text,
+  summary text,
+  responsibilities text[],
+  requirements text[],
+  desirables text[],
+  salary_range text,
+  benefits text,
+  contract_type text,
+  workload text,
+  seniority text,
+  form_fields jsonb default '["name","email"]',
+  created_at timestamptz default now(),
+  created_by uuid references auth.users(id),
+  constraint jobs_manager_fkey foreign key (company_id, manager_id)
+    references companies_users(company_id, user_id)
+);
+comment on table jobs is 'Vagas de recrutamento';
+
+create table if not exists job_stages (
+  id uuid primary key default uuid_generate_v4(),
+  company_id uuid not null references companies(id) on delete cascade,
+  job_id uuid references jobs(id) on delete cascade,
+  name text not null,
+  position int not null,
+  sla_days int,
+  unique (job_id,position)
+);
+
+-- Applications
+create table if not exists applications (
+  id uuid primary key default uuid_generate_v4(),
+  company_id uuid not null references companies(id) on delete cascade,
+  job_id uuid not null references jobs(id) on delete cascade,
+  talent_id uuid not null references talents(id) on delete cascade,
+  status application_status default 'applied',
+  applied_at timestamptz default now(),
+  source candidate_source,
+  notes text,
+  unique (job_id,talent_id)
+);
+
+-- Ensure legacy installations have the stage reference
+alter table if exists applications
+  add column if not exists stage_id uuid references job_stages(id);
+
+create table if not exists application_stage_history (
+  id uuid primary key default uuid_generate_v4(),
+  application_id uuid not null references applications(id) on delete cascade,
+  from_stage uuid references job_stages(id),
+  to_stage uuid not null references job_stages(id),
+  moved_at timestamptz default now(),
+  moved_by uuid references auth.users(id),
+  reason rejection_reason,
+  note text,
+  due_at timestamptz,
+  breached_at timestamptz
+);
+
+create table if not exists application_events (
+  id uuid primary key default uuid_generate_v4(),
+  company_id uuid not null references companies(id) on delete cascade,
+  application_id uuid references applications(id) on delete cascade,
+  event_type text not null,
+  payload jsonb not null default '{}',
+  created_at timestamptz default now(),
+  created_by uuid references auth.users(id)
+);
+comment on table application_events is 'Auditoria de ações do pipeline';
+
+create table if not exists reports_cache (
+  company_id uuid not null references companies(id) on delete cascade,
+  period_start date not null,
+  period_end date not null,
+  metric text not null,
+  value numeric not null,
+  primary key (company_id,metric,period_start,period_end)
+);
+
+-- RLS policies
+alter table talents enable row level security;
+alter table talent_tags enable row level security;
+alter table talent_tag_map enable row level security;
+alter table skills enable row level security;
+alter table talent_skill_map enable row level security;
+alter table jobs enable row level security;
+alter table job_stages enable row level security;
+alter table applications enable row level security;
+alter table application_stage_history enable row level security;
+alter table application_events enable row level security;
+alter table reports_cache enable row level security;
+
+-- Basic company isolation policies
+create policy company_iso on talents using (company_id = (auth.jwt() ->> 'company_id')::uuid) with check (company_id = (auth.jwt() ->> 'company_id')::uuid);
+create policy company_iso on talent_tags using (company_id = (auth.jwt() ->> 'company_id')::uuid) with check (company_id = (auth.jwt() ->> 'company_id')::uuid);
+create policy company_iso on skills using (company_id = (auth.jwt() ->> 'company_id')::uuid) with check (company_id = (auth.jwt() ->> 'company_id')::uuid);
+create policy company_iso on jobs using (company_id = (auth.jwt() ->> 'company_id')::uuid) with check (company_id = (auth.jwt() ->> 'company_id')::uuid);
+create policy company_iso on job_stages using (company_id = (auth.jwt() ->> 'company_id')::uuid) with check (company_id = (auth.jwt() ->> 'company_id')::uuid);
+create policy company_iso on applications using (company_id = (auth.jwt() ->> 'company_id')::uuid) with check (company_id = (auth.jwt() ->> 'company_id')::uuid);
+create policy company_iso on application_stage_history using (exists (select 1 from applications a where a.id = application_stage_history.application_id and a.company_id = (auth.jwt() ->> 'company_id')::uuid));
+create policy company_iso on application_events using (company_id = (auth.jwt() ->> 'company_id')::uuid) with check (company_id = (auth.jwt() ->> 'company_id')::uuid);
+create policy company_iso on reports_cache using (company_id = (auth.jwt() ->> 'company_id')::uuid) with check (company_id = (auth.jwt() ->> 'company_id')::uuid);
+
+-- Role based write policies
+create policy talents_write on talents for all using (auth.jwt() ->> 'company_role' in ('admin','recruiter','manager') and company_id = (auth.jwt() ->> 'company_id')::uuid);
+create policy jobs_write on jobs for all using (auth.jwt() ->> 'company_role' in ('admin','recruiter','manager') and company_id = (auth.jwt() ->> 'company_id')::uuid);
+create policy job_stages_write on job_stages for all using (auth.jwt() ->> 'company_role' in ('admin','recruiter','manager') and company_id = (auth.jwt() ->> 'company_id')::uuid);
+create policy applications_write on applications for all using (auth.jwt() ->> 'company_role' in ('admin','recruiter','manager') and company_id = (auth.jwt() ->> 'company_id')::uuid);
+
+-- Read-only policy for all roles
+create policy read_all on talents for select using (company_id = (auth.jwt() ->> 'company_id')::uuid);
+create policy read_all on jobs for select using (company_id = (auth.jwt() ->> 'company_id')::uuid);
+create policy read_all on job_stages for select using (company_id = (auth.jwt() ->> 'company_id')::uuid);
+create policy read_all on applications for select using (company_id = (auth.jwt() ->> 'company_id')::uuid);


### PR DESCRIPTION
## Summary
- revert broad layout/Sidebar changes and remove unused recruitment metrics
- wrap "Sobre a vaga" sections in card components for a cleaner layout

## Testing
- `npm test`
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b8095000832d80ba40f5202df39b