### PR TITLE
feat: add talent status filter and job metrics funnel

### DIFF
--- a/components/recruitment/JobMetrics.tsx
+++ b/components/recruitment/JobMetrics.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../../lib/supabaseClient';
+import { ChartContainer } from '../ui/chart';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  LabelList,
+} from 'recharts';
+
+interface Props {
+  jobId: string;
+}
+
+export default function JobMetrics({ jobId }: Props) {
+  const [data, setData] = useState<
+    { name: string; half: number; value: number }[]
+  >([]);
+  const [maxHalf, setMaxHalf] = useState(0);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const { data: stages } = await supabase
+          .from('job_stages')
+          .select('id,name,position')
+          .eq('job_id', jobId)
+          .order('position');
+
+        const { data: apps } = await supabase
+          .from('applications')
+          .select('stage_id')
+          .eq('job_id', jobId);
+
+        const counts: Record<string, number> = {};
+        (apps || []).forEach((a) => {
+          const key = a.stage_id || 'none';
+          counts[key] = (counts[key] || 0) + 1;
+        });
+
+        const { data: metric, error: metricError } = await supabase
+          .from('job_metrics')
+          .select('link_clicks')
+          .eq('job_id', jobId)
+          .maybeSingle();
+
+        const clicks = metricError ? 0 : metric?.link_clicks || 0;
+
+        const stageData = (stages || [])
+          .map((s) => ({ name: s.name, value: counts[s.id] || 0 }))
+          .filter((d) => d.value > 0);
+
+        const rawData = [
+          { name: 'Cliques no link', value: clicks },
+          ...stageData,
+        ].filter((d) => d.value > 0);
+
+        const chartData = rawData.map((d) => ({
+          name: d.name,
+          half: d.value / 2,
+          value: d.value,
+        }));
+
+        setData(chartData);
+        const maxVal = rawData.reduce((m, d) => Math.max(m, d.value), 0);
+        setMaxHalf(maxVal / 2);
+      } catch (e) {
+        console.error('Failed to load job metrics', e);
+      }
+    };
+    load();
+  }, [jobId]);
+
+  return (
+    <div className="max-w-md mx-auto space-y-4">
+      <h3 className="text-lg font-semibold text-center">Funil de candidatos</h3>
+      <ChartContainer>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data} layout="vertical" margin={{ left: 40, right: 40 }}>
+            <XAxis
+              type="number"
+              domain={[-maxHalf, maxHalf]}
+              hide
+              axisLine={false}
+              tickLine={false}
+            />
+            <YAxis
+              dataKey="name"
+              type="category"
+              hide
+              axisLine={false}
+              tickLine={false}
+            />
+            <Tooltip content={<FunnelTooltip />} />
+            <Bar
+              dataKey="half"
+              barSize={24}
+              shape={(props) => <CenteredBar {...props} />}
+            >
+              <LabelList
+                dataKey="value"
+                content={(props) => <CenteredLabel {...props} />}
+              />
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </ChartContainer>
+    </div>
+  );
+}
+
+function CenteredBar({ x, y, width, height }: any) {
+  const halfWidth = width;
+  return (
+    <rect
+      x={x - halfWidth}
+      y={y}
+      width={halfWidth * 2}
+      height={height}
+      fill="#a855f7"
+      rx={2}
+      ry={2}
+    />
+  );
+}
+
+function CenteredLabel({ x, y, height, width, payload }: any) {
+  if (!payload) return null;
+  const midY = y + height / 2;
+  // `x` from Recharts represents the axis zero point for our custom bar,
+  // so we can use it directly to center the label.
+  const centerX = x;
+  return (
+    <text
+      x={centerX}
+      y={midY}
+      textAnchor="middle"
+      dominantBaseline="middle"
+      fill="white"
+      className="text-xs"
+    >
+      <tspan x={centerX} dy="-0.6em">
+        {payload.name}
+      </tspan>
+      <tspan x={centerX} dy="1.2em">
+        {payload.value}
+      </tspan>
+    </text>
+  );
+}
+
+function FunnelTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: any[];
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+  const value = payload[0].payload.value;
+  return (
+    <div className="rounded-md border bg-white px-2 py-1 text-xs shadow-sm">
+      <p className="font-medium mb-1">{label}</p>
+      <div className="flex items-center gap-2">
+        <span className="h-2 w-2 rounded-full" style={{ backgroundColor: '#a855f7' }} />
+        <span>{value}</span>
+      </div>
+    </div>
+  );
+}

--- a/components/recruitment/JobTalentBoard.tsx
+++ b/components/recruitment/JobTalentBoard.tsx
@@ -25,6 +25,7 @@ interface ApplicationItem {
   created_at: string;
   source: string | null;
   tags: Tag[];
+  status: string;
 }
 
 const DEFAULT_STAGES = [
@@ -50,6 +51,7 @@ export default function JobTalentBoard({ jobId }: Props) {
     talentId: string;
     appId: string;
   } | null>(null);
+  const [statusFilter, setStatusFilter] = useState('active');
 
   const load = async () => {
     const {
@@ -80,7 +82,7 @@ export default function JobTalentBoard({ jobId }: Props) {
     const { data: appData } = await supabase
       .from('applications')
       .select(
-        'id,stage_id,talent:talents(id,name,created_at,source,talent_tag_map(tag:talent_tags(name,color)))'
+        'id,stage_id,talent:talents(id,name,created_at,source,status,talent_tag_map(tag:talent_tags(name,color)))'
       )
       .eq('company_id', compId)
       .eq('job_id', jobId);
@@ -97,6 +99,7 @@ export default function JobTalentBoard({ jobId }: Props) {
             name: m.tag.name,
             color: m.tag.color || '#a855f7',
           })) || [],
+        status: a.talent.status,
       })) || [];
     setItems(mapped);
   };
@@ -138,7 +141,9 @@ export default function JobTalentBoard({ jobId }: Props) {
 
   const grouped = stages.map((s) => ({
     stage: s,
-    items: items.filter((t) => t.stage_id === s.id),
+    items: items.filter(
+      (t) => t.stage_id === s.id && t.status === statusFilter
+    ),
   }));
 
   return (
@@ -148,6 +153,28 @@ export default function JobTalentBoard({ jobId }: Props) {
         <Button variant="outline" onClick={() => setStageOpen(true)}>
           Etapas
         </Button>
+      </div>
+      <div className="mb-4">
+        <div className="flex border-b border-gray-200">
+          {[
+            { value: 'active', label: 'Ativos' },
+            { value: 'withdrawn', label: 'Desistentes' },
+            { value: 'rejected', label: 'Reprovados' },
+          ].map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => setStatusFilter(opt.value)}
+              className={
+                'flex-1 px-4 py-2 text-sm font-medium ' +
+                (statusFilter === opt.value
+                  ? 'border-b-2 border-brand text-brand'
+                  : 'text-gray-500')
+              }
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
       </div>
       <div className="flex gap-4 overflow-x-auto">
         {grouped.map(({ stage, items }) => (

--- a/components/recruitment/TalentModal.tsx
+++ b/components/recruitment/TalentModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { supabase } from '../../lib/supabaseClient';
 import { Button } from '../ui/button';
-import { X, Settings } from 'lucide-react';
+import { X, Settings, ChevronDown } from 'lucide-react';
 import TagSidebar from '../TagSidebar';
 
 interface Tag {
@@ -27,6 +27,7 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
   const [seniority, setSeniority] = useState('');
   const [availability, setAvailability] = useState('');
   const [source, setSource] = useState('');
+  const [status, setStatus] = useState('active');
   const [comment, setComment] = useState('');
   const [tags, setTags] = useState<Tag[]>([]);
   const [newTag, setNewTag] = useState('');
@@ -39,7 +40,7 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
       const { data: talent } = await supabase
         .from('talents')
         .select(
-          'name,email,phone,city,state,cv_url,salary_expectation,seniority,availability,source,comment,talent_tag_map(tag:talent_tags(name,color))'
+          'name,email,phone,city,state,cv_url,salary_expectation,seniority,availability,source,status,comment,talent_tag_map(tag:talent_tags(name,color))'
         )
         .eq('id', talentId)
         .single();
@@ -54,6 +55,7 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
         setSeniority(talent.seniority || '');
         setAvailability(talent.availability || '');
         setSource(talent.source || '');
+        setStatus(talent.status || 'active');
         setComment(talent.comment || '');
         setTags(
           talent.talent_tag_map?.map((m: any) => ({
@@ -119,6 +121,7 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
         seniority,
         availability,
         source,
+        status,
         comment,
       })
       .eq('id', talentId);
@@ -230,11 +233,20 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
           </div>
           <div>
             <label className="block text-sm font-medium mb-1">Senioridade</label>
-            <input
-              className="w-full border p-2 rounded"
-              value={seniority}
-              onChange={(e) => setSeniority(e.target.value)}
-            />
+            <div className="relative">
+              <select
+                className="w-full border p-2 rounded appearance-none pr-8"
+                value={seniority}
+                onChange={(e) => setSeniority(e.target.value)}
+              >
+                <option value="">Selecione</option>
+                <option value="junior">Junior</option>
+                <option value="pleno">Pleno</option>
+                <option value="senior">Senior</option>
+                <option value="especialista">Especialista</option>
+              </select>
+              <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500 pointer-events-none" />
+            </div>
           </div>
           <div>
             <label className="block text-sm font-medium mb-1">Disponibilidade</label>
@@ -246,19 +258,44 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
           </div>
           <div>
             <label className="block text-sm font-medium mb-1">Fonte</label>
-            <select
-              className="w-full border p-2 rounded appearance-none pr-6"
-              value={source}
-              onChange={(e) => setSource(e.target.value)}
-            >
-              <option value="">Selecione</option>
-              <option value="career_site">Site</option>
-              <option value="referral">Indicação</option>
-              <option value="linkedin">LinkedIn</option>
-              <option value="import">Importação</option>
-              <option value="event">Evento</option>
-              <option value="other">Outro</option>
-            </select>
+            <div className="relative">
+              <select
+                className="w-full border p-2 rounded appearance-none pr-8"
+                value={source}
+                onChange={(e) => setSource(e.target.value)}
+              >
+                <option value="">Selecione</option>
+                <option value="career_site">Site</option>
+                <option value="referral">Indicação</option>
+                <option value="linkedin">LinkedIn</option>
+                <option value="import">Importação</option>
+                <option value="event">Evento</option>
+                <option value="other">Outro</option>
+              </select>
+              <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500 pointer-events-none" />
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Status</label>
+            <div className="space-y-2">
+              {[
+                { value: 'active', label: 'Ativo' },
+                { value: 'withdrawn', label: 'Desistente' },
+                { value: 'rejected', label: 'Reprovado' },
+              ].map((opt) => (
+                <label key={opt.value} className="flex items-center gap-2 text-sm">
+                  <input
+                    type="radio"
+                    name="status"
+                    value={opt.value}
+                    checked={status === opt.value}
+                    onChange={(e) => setStatus(e.target.value)}
+                    className="h-4 w-4 accent-brand"
+                  />
+                  {opt.label}
+                </label>
+              ))}
+            </div>
           </div>
           <div className="sm:col-span-2">
             <div className="flex items-center justify-between mb-1">
@@ -284,9 +321,9 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
               ))}
             </div>
             <div className="flex flex-wrap items-center gap-2">
-              <div className="flex-1">
+              <div className="flex-1 relative">
                 <input
-                  className="w-full border p-2 rounded appearance-none"
+                  className="w-full border p-2 rounded appearance-none pr-8"
                   placeholder="Adicionar tag"
                   value={newTag}
                   list="tag-suggestions"
@@ -297,6 +334,7 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
                     setNewColor(found?.color || '#a855f7');
                   }}
                 />
+                <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500 pointer-events-none" />
               </div>
               <datalist id="tag-suggestions">
                 {suggestions.map((s) => (

--- a/docs/recruitment-selection.md
+++ b/docs/recruitment-selection.md
@@ -15,6 +15,7 @@ Principais objetivos:
 - **skills**, **talent_skill_map**: habilidades técnicas ou comportamentais.
 - **jobs**: vagas com status e etapas personalizadas.
 - **job_stages**: etapas padrão por empresa ou sobrescritas por vaga.
+- **job_metrics**: estatísticas agregadas por vaga (ex.: cliques no link).
 - **applications**: vínculo talento↔vaga com estágio atual.
 - **application_stage_history**: histórico de mudanças de etapa e SLAs.
 - **application_events**: auditoria de ações (quem, quando, payload).
@@ -26,6 +27,7 @@ Principais objetivos:
 - `applications.job_id -> jobs.id`
 - `applications.talent_id -> talents.id`
 - `job_stages.job_id -> jobs.id` (ou nulo para padrão da empresa)
+- `job_metrics.job_id -> jobs.id`
 - `application_stage_history.application_id -> applications.id`
 - `application_events.application_id -> applications.id`
 
@@ -37,6 +39,7 @@ create type job_status as enum ('open','closed','frozen');
 create type application_stage as enum ('applied','screening','interview','offer','admitted','rejected','withdrawn');
 create type candidate_source as enum ('career_site','referral','linkedin','import','event','other');
 create type rejection_reason as enum ('lack_of_skill','cultural_fit','salary','position_filled','candidate_withdrew','other');
+create type talent_status as enum ('active','withdrawn','rejected');
 
 -- Talents
 create table talents (
@@ -54,6 +57,7 @@ create table talents (
   seniority text,
   availability text,
   source candidate_source,
+  status talent_status default 'active',
   consent_at timestamptz,
   created_at timestamptz default now(),
   updated_at timestamptz default now(),

--- a/pages/apply/[id].tsx
+++ b/pages/apply/[id].tsx
@@ -101,5 +101,6 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   if (!job) {
     return { notFound: true };
   }
+  await supabase.rpc('increment_job_link_click', { j: job.id });
   return { props: { job } };
 };

--- a/pages/recruitment/jobs/[id].tsx
+++ b/pages/recruitment/jobs/[id].tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import Layout from '../../../components/Layout';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../../../components/ui/tabs';
 import JobTalentBoard from '../../../components/recruitment/JobTalentBoard';
+import JobMetrics from '../../../components/recruitment/JobMetrics';
 import { supabase } from '../../../lib/supabaseClient';
 import { Input } from '../../../components/ui/input';
 import { Button } from '../../../components/ui/button';
@@ -573,7 +574,7 @@ export default function JobDetails() {
             )}
           </TabsContent>
           <TabsContent value="metrics">
-            <p>Métricas em construção.</p>
+            {id && !Array.isArray(id) && <JobMetrics jobId={id} />}
           </TabsContent>
           <TabsContent value="ads">
             <div className="space-y-4">

--- a/supabaserecrutamento.sql
+++ b/supabaserecrutamento.sql
@@ -9,6 +9,7 @@ create type job_status as enum ('open','closed','frozen');
 create type application_status as enum ('applied','screening','interview','offer','admitted','rejected','withdrawn');
 create type candidate_source as enum ('career_site','referral','linkedin','import','event','other');
 create type rejection_reason as enum ('lack_of_skill','cultural_fit','salary','position_filled','candidate_withdrew','other');
+create type talent_status as enum ('active','withdrawn','rejected');
 
 -- Talents
 create table if not exists talents (
@@ -27,6 +28,7 @@ create table if not exists talents (
   seniority text,
   availability text,
   source candidate_source,
+  status talent_status default 'active',
   consent_at timestamptz,
   created_at timestamptz default now(),
   updated_at timestamptz default now(),
@@ -101,6 +103,19 @@ create table if not exists job_stages (
   sla_days int,
   unique (job_id,position)
 );
+
+create table if not exists job_metrics (
+  job_id uuid primary key references jobs(id) on delete cascade,
+  link_clicks int default 0
+);
+
+create or replace function increment_job_link_click(j uuid)
+returns void as $$
+  insert into job_metrics(job_id, link_clicks)
+  values (j, 1)
+  on conflict (job_id)
+    do update set link_clicks = job_metrics.link_clicks + 1;
+$$ language sql;
 
 -- Applications
 create table if not exists applications (


### PR DESCRIPTION
## Summary
- add `status` column and enum for talents
- filter talents in job board by status with Ativos/Desistentes/Reprovados tabs
- allow updating a talent's status from the talent detail modal using radio buttons
- style status filter tabs to match main recruitment top bar and simplify modal status selection
- enhance talent modal with purple-accent status radios, dropdown arrows, and a seniority selector
- track job link clicks in new `job_metrics` table and expose an increment function
- increment link click count on public job page and render funnel chart of clicks and stage counts on Metrics tab
- center funnel bars around a middle axis so each stage's bar is symmetrically indented
- add "Funil de candidatos" heading and display totals and labels inside each funnel bar while hiding the center axis line
- move stage labels from chart axis to inside bars alongside totals
- skip funnel stages with zero counts to avoid client-side errors
- fallback to zero link clicks if job metrics are missing and guard funnel labels from undefined payloads
- show each funnel stage name and its count on separate lines centered within the bar

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ac63d41c88832dae428256b68eda1c