### PR TITLE
feat: add talent status filter and job metrics funnel

### DIFF
--- a/components/StageSidebar.tsx
+++ b/components/StageSidebar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { GripVertical } from 'lucide-react';
 import { supabase } from '../lib/supabaseClient';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
@@ -14,13 +15,15 @@ interface Props {
   open: boolean;
   onClose: () => void;
   jobId?: string;
+  onOrderChange?: (stages: Stage[]) => void;
 }
 
-export default function StageSidebar({ open, onClose, jobId }: Props) {
+export default function StageSidebar({ open, onClose, jobId, onOrderChange }: Props) {
   const [stages, setStages] = useState<Stage[]>([]);
   const [companyId, setCompanyId] = useState('');
   const [name, setName] = useState('');
   const [sla, setSla] = useState('');
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -42,24 +45,55 @@ export default function StageSidebar({ open, onClose, jobId }: Props) {
       if (jobId) query.eq('job_id', jobId); else query.is('job_id', null);
       const { data } = await query;
       setStages(data || []);
+      onOrderChange?.((data || []).sort((a, b) => a.position - b.position));
     };
     load();
-  }, [open]);
+  }, [open, onOrderChange]);
+
+  const persistOrder = async (list: Stage[]) => {
+    const ordered = list.map((s, i) => ({ ...s, position: i + 1 }));
+    setStages(ordered);
+    onOrderChange?.(ordered);
+    console.log('persistOrder start ->', ordered.map(({ id, position }) => ({ id, position })));
+    try {
+      // First move everything to a unique negative position to avoid conflicts
+      for (const { id, position } of ordered) {
+        const tempPos = -(position + 1000);
+        const { error } = await supabase
+          .from('job_stages')
+          .update({ position: tempPos })
+          .eq('id', id);
+        console.log('temp update', { id, tempPos, error });
+      }
+
+      // Then apply the final sequential positions
+      for (const { id, position } of ordered) {
+        const { error } = await supabase
+          .from('job_stages')
+          .update({ position })
+          .eq('id', id);
+        console.log('final update', { id, position, error });
+      }
+    } catch (err) {
+      console.error('persistOrder failed', err);
+    }
+  };
 
   const add = async () => {
+    const nextPos = stages.reduce((max, s) => Math.max(max, s.position), 0) + 1;
     const { data, error } = await supabase
       .from('job_stages')
       .insert({
         company_id: companyId,
         job_id: jobId ?? null,
         name,
-        position: stages.length + 1,
+        position: nextPos,
         sla_days: sla ? Number(sla) : null,
       })
       .select('id,name,position,sla_days')
       .single();
     if (!error && data) {
-      setStages([...stages, data]);
+      await persistOrder([...stages, data]);
       setName('');
       setSla('');
     }
@@ -68,13 +102,36 @@ export default function StageSidebar({ open, onClose, jobId }: Props) {
   const save = async (stage: Stage) => {
     await supabase
       .from('job_stages')
-      .update({ name: stage.name, position: stage.position, sla_days: stage.sla_days })
+      .update({ name: stage.name, sla_days: stage.sla_days })
       .eq('id', stage.id);
+    setStages((prev) => [...prev]);
+    onOrderChange?.(
+      [...stages].sort((a, b) => a.position - b.position)
+    );
   };
 
   const remove = async (id: string) => {
     await supabase.from('job_stages').delete().eq('id', id);
-    setStages(stages.filter((s) => s.id !== id));
+    await persistOrder(stages.filter((s) => s.id !== id));
+  };
+
+  const handleDragStart = (index: number) => setDragIndex(index);
+
+  const handleDragOver = (index: number, e: React.DragEvent) => {
+    e.preventDefault();
+    if (dragIndex === null || dragIndex === index) return;
+    const updated = [...stages];
+    const [moved] = updated.splice(dragIndex, 1);
+    updated.splice(index, 0, moved);
+    setDragIndex(index);
+    setStages(updated);
+  };
+
+  const handleDragEnd = () => {
+    if (dragIndex === null) return;
+    console.log('handleDragEnd ->', stages.map(({ id, position }) => ({ id, position })));
+    persistOrder(stages);
+    setDragIndex(null);
   };
 
   if (!open) return null;
@@ -106,15 +163,16 @@ export default function StageSidebar({ open, onClose, jobId }: Props) {
             </Button>
           </div>
         </div>
-        {stages.map((st) => (
-          <div key={st.id} className="grid grid-cols-6 gap-2 mb-2 items-center">
-            <Input
-              value={st.position}
-              type="number"
-              onChange={(e) => (st.position = Number(e.target.value))}
-              onBlur={() => save(st)}
-              className="col-span-1"
-            />
+        {stages.map((st, i) => (
+          <div
+            key={st.id}
+            className="grid grid-cols-6 gap-2 mb-2 items-center cursor-move"
+            draggable
+            onDragStart={() => handleDragStart(i)}
+            onDragOver={(e) => handleDragOver(i, e)}
+            onDragEnd={handleDragEnd}
+          >
+            <GripVertical className="col-span-1 h-4 w-4 justify-self-center" />
             <Input
               value={st.name}
               onChange={(e) => (st.name = e.target.value)}

--- a/components/recruitment/JobMetrics.tsx
+++ b/components/recruitment/JobMetrics.tsx
@@ -1,0 +1,427 @@
+import { useEffect, useState, useRef } from 'react';
+import { supabase } from '../../lib/supabaseClient';
+import { ChartContainer } from '../ui/chart';
+import { Card } from '../ui/card';
+import { Button } from '../ui/button';
+import { Download } from 'lucide-react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  LabelList,
+  RadarChart,
+  Radar,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+} from 'recharts';
+
+interface Props {
+  jobId: string;
+}
+
+const CHART_MARGIN = { left: 20, right: 20 };
+const Y_AXIS_WIDTH = 180;
+
+export default function JobMetrics({ jobId }: Props) {
+  const [data, setData] = useState<
+    { name: string; half: number; value: number }[]
+  >([]);
+  const [maxHalf, setMaxHalf] = useState(0);
+  const [timeToFill, setTimeToFill] = useState(0);
+  const [stageDurations, setStageDurations] = useState<
+    { name: string; avg: number; sla: number }[]
+  >([]);
+  const chartRef = useRef<HTMLDivElement>(null);
+  const radarRef = useRef<HTMLDivElement>(null);
+
+  const handleDownload = () => {
+    if (!chartRef.current) return;
+    const svg = chartRef.current.querySelector('svg');
+    if (!svg) return;
+    const serializer = new XMLSerializer();
+    const svgStr = serializer.serializeToString(svg);
+    const canvas = document.createElement('canvas');
+    canvas.width = svg.clientWidth;
+    canvas.height = svg.clientHeight;
+    const ctx = canvas.getContext('2d');
+    const img = new Image();
+    const blob = new Blob([svgStr], { type: 'image/svg+xml;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    img.onload = () => {
+      ctx?.drawImage(img, 0, 0);
+      URL.revokeObjectURL(url);
+      const a = document.createElement('a');
+      a.download = 'funil-de-candidatos.png';
+      a.href = canvas.toDataURL('image/png');
+      a.click();
+    };
+    img.src = url;
+  };
+
+  const handleDownloadRadar = () => {
+    if (!radarRef.current) return;
+    const svg = radarRef.current.querySelector('svg');
+    if (!svg) return;
+    const serializer = new XMLSerializer();
+    const svgStr = serializer.serializeToString(svg);
+    const canvas = document.createElement('canvas');
+    canvas.width = svg.clientWidth;
+    canvas.height = svg.clientHeight;
+    const ctx = canvas.getContext('2d');
+    const img = new Image();
+    const blob = new Blob([svgStr], { type: 'image/svg+xml;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    img.onload = () => {
+      ctx?.drawImage(img, 0, 0);
+      URL.revokeObjectURL(url);
+      const a = document.createElement('a');
+      a.download = 'tempo-medio-etapas.png';
+      a.href = canvas.toDataURL('image/png');
+      a.click();
+    };
+    img.src = url;
+  };
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const { data: stages } = await supabase
+          .from('job_stages')
+          .select('id,name,position,sla_days')
+          .eq('job_id', jobId)
+          .order('position');
+
+        const { data: apps } = await supabase
+          .from('applications')
+          .select('id,stage_id,applied_at')
+          .eq('job_id', jobId);
+
+        const counts: Record<string, number> = {};
+        (apps || []).forEach((a) => {
+          const key = a.stage_id || 'none';
+          counts[key] = (counts[key] || 0) + 1;
+        });
+
+        const appIds = (apps || []).map((a) => a.id);
+        const { data: dateRows } = await supabase
+          .from('application_stage_dates')
+          .select('application_id,stage_id,day_in,day_out')
+          .in('application_id', appIds);
+
+        const stageMap = new Map(
+          (stages || []).map((s) => [s.id, { name: s.name, sla: s.sla_days }])
+        );
+
+        const datesByApp: Record<string, any[]> = {};
+        (dateRows || []).forEach((d) => {
+          if (!datesByApp[d.application_id]) datesByApp[d.application_id] = [];
+          datesByApp[d.application_id].push(d);
+        });
+
+        let totalFill = 0;
+        let fillCount = 0;
+        const stats: Record<string, { total: number; count: number; slaHits: number; slaTotal: number }> = {};
+
+        Object.entries(datesByApp).forEach(([appId, records]) => {
+          const ins = records.map((r: any) => new Date(r.day_in).getTime());
+          const outs = records
+            .map((r: any) => (r.day_out ? new Date(r.day_out).getTime() : null))
+            .filter((t: number | null): t is number => t !== null);
+          if (ins.length && outs.length) {
+            const first = Math.min(...ins);
+            const last = Math.max(...outs);
+            totalFill += (last - first) / 86400000;
+            fillCount++;
+          }
+          records.forEach((r: any) => {
+            if (!r.day_in) return;
+            const start = new Date(r.day_in).getTime();
+            const end = r.day_out ? new Date(r.day_out).getTime() : Date.now();
+            const duration = (end - start) / 86400000;
+            const st = stats[r.stage_id] || {
+              total: 0,
+              count: 0,
+              slaHits: 0,
+              slaTotal: 0,
+            };
+            st.total += duration;
+            st.count++;
+            const sla = stageMap.get(r.stage_id)?.sla;
+            if (sla) {
+              st.slaTotal++;
+              if (duration <= sla) st.slaHits++;
+            }
+            stats[r.stage_id] = st;
+          });
+        });
+
+        setTimeToFill(fillCount ? totalFill / fillCount : 0);
+        const durationArr = Object.entries(stats).map(([id, s]) => ({
+          name: stageMap.get(id)?.name || 'Etapa',
+          avg: s.count ? s.total / s.count : 0,
+          sla: s.slaTotal ? (s.slaHits / s.slaTotal) * 100 : 0,
+        }));
+        setStageDurations(durationArr);
+
+        const { data: metric, error: metricError } = await supabase
+          .from('job_metrics')
+          .select('link_clicks')
+          .eq('job_id', jobId)
+          .maybeSingle();
+
+        const clicks = metricError ? 0 : metric?.link_clicks || 0;
+
+        const stageData = (stages || [])
+          .map((s) => ({ name: s.name, value: counts[s.id] || 0 }));
+
+        for (let i = stageData.length - 1; i >= 0; i--) {
+          const next = i < stageData.length - 1 ? stageData[i + 1].value : 0;
+          stageData[i].value += next;
+        }
+
+        const filteredStages = stageData.filter((d) => d.value > 0);
+
+        const rawData = [
+          { name: 'Cliques no link', value: clicks },
+          ...filteredStages,
+        ].filter((d) => d.value > 0);
+
+        const chartData = rawData.map((d) => ({
+          name: d.name,
+          half: d.value / 2,
+          value: d.value,
+        }));
+
+        setData(chartData);
+        const maxVal = rawData.reduce((m, d) => Math.max(m, d.value), 0);
+        setMaxHalf(maxVal / 2);
+      } catch (e) {
+        console.error('Failed to load job metrics', e);
+      }
+    };
+    load();
+  }, [jobId]);
+
+  const radarData = stageDurations.map((s) => ({ stage: s.name, value: s.avg }));
+  const maxAvg = radarData.reduce((m, d) => Math.max(m, d.value), 0);
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <Card>
+        <div className="flex items-center justify-between p-4 pb-0">
+          <h2 className="font-semibold">Funil de candidatos</h2>
+          <Button variant="outline" size="sm" onClick={handleDownload}>
+            <Download className="h-4 w-4" />
+          </Button>
+        </div>
+        <ChartContainer ref={chartRef} className="mt-4">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={data} layout="vertical" margin={CHART_MARGIN}>
+              <XAxis
+                type="number"
+                domain={[-maxHalf, maxHalf]}
+                hide
+                axisLine={false}
+                tickLine={false}
+              />
+              <YAxis
+                dataKey="name"
+                type="category"
+                axisLine={false}
+                tickLine={false}
+                width={Y_AXIS_WIDTH}
+                tick={(props) => <StageTick {...props} />}
+              />
+              <Tooltip content={<FunnelTooltip />} />
+              <Bar
+                dataKey="half"
+                barSize={48}
+                shape={(props) => <CenteredBar {...props} />}
+              >
+                <LabelList
+                  dataKey="value"
+                  content={(props) => <CenteredValue {...props} />}
+                />
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartContainer>
+      </Card>
+      <Card>
+        <div className="p-4">
+          <h2 className="font-semibold mb-4">Tempo</h2>
+          <div className="grid gap-4 md:grid-cols-2">
+            <Card>
+              <div className="p-4">
+                <h3 className="font-medium">Tempo médio para preencher vaga</h3>
+                <p className="text-2xl font-semibold text-center">
+                  {formatDuration(timeToFill)}
+                </p>
+              </div>
+            </Card>
+            <Card>
+              <div className="p-4">
+                <h3 className="font-medium">SLA compliance</h3>
+                {stageDurations.length ? (
+                  <ul className="ml-4 list-disc text-sm">
+                    {stageDurations.map((s) => (
+                      <li key={s.name}>{`${s.name}: ${s.sla.toFixed(0)}%`}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-sm">Sem dados</p>
+                )}
+              </div>
+            </Card>
+            <Card className="md:col-span-2">
+              <div className="flex items-center justify-between p-4 pb-0">
+                <h3 className="font-medium">Tempo médio em cada etapa</h3>
+                <Button variant="outline" size="sm" onClick={handleDownloadRadar}>
+                  <Download className="h-4 w-4" />
+                </Button>
+              </div>
+              {radarData.length ? (
+                <ChartContainer
+                  ref={radarRef}
+                  className="mx-auto aspect-square max-h-[350px] mt-4"
+                >
+                  <ResponsiveContainer width="100%" height="100%">
+                    <RadarChart
+                      data={radarData}
+                      outerRadius={120}
+                      margin={{ top: 40, right: 40, bottom: 40, left: 40 }}
+                    >
+                      <PolarGrid />
+                      <PolarAngleAxis
+                        dataKey="stage"
+                        tick={({ x, y, payload, cx, cy, index }: any) => {
+                          const d = radarData.find((r) => r.stage === payload.value);
+                          const dx = x - cx;
+                          const dy = y - cy;
+                          const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+                          const offset = 30;
+                          const newX = cx + (dx / dist) * (dist + offset);
+                          const newY = cy + (dy / dist) * (dist + offset);
+                          return (
+                            <text
+                              x={newX}
+                              y={newY}
+                              textAnchor="middle"
+                              fontSize={12}
+                              fontWeight={500}
+                            >
+                              <tspan x={newX}>{payload.value}</tspan>
+                              <tspan
+                                x={newX}
+                                dy="1rem"
+                                fontSize={12}
+                                className="fill-muted-foreground"
+                              >
+                                {d ? formatDuration(d.value) : ''}
+                              </tspan>
+                            </text>
+                          );
+                        }}
+                      />
+                      <PolarRadiusAxis domain={[0, maxAvg]} tick={false} />
+                      <Radar
+                        dataKey="value"
+                        stroke="#a855f7"
+                        fill="#a855f7"
+                        fillOpacity={0.6}
+                      />
+                    </RadarChart>
+                  </ResponsiveContainer>
+                </ChartContainer>
+              ) : (
+                <p className="text-sm text-center">Sem dados</p>
+              )}
+            </Card>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function CenteredBar({ x, y, width, height }: any) {
+  const halfWidth = width;
+  return (
+    <rect
+      x={x - halfWidth}
+      y={y}
+      width={halfWidth * 2}
+      height={height}
+      fill="#a855f7"
+      rx={2}
+      ry={2}
+    />
+  );
+}
+
+function CenteredValue({ value, viewBox }: any) {
+  if (value == null || !viewBox) return null;
+  const { x, y, height } = viewBox;
+  const centerX = x;
+  const centerY = y + height / 2;
+  return (
+    <text
+      x={centerX}
+      y={centerY}
+      textAnchor="middle"
+      dominantBaseline="middle"
+      fill="white"
+      className="text-xs font-medium"
+    >
+      {value}
+    </text>
+  );
+}
+
+function StageTick({ x, y, payload }: any) {
+  return (
+    <text
+      x={x - 16}
+      y={y}
+      dy={4}
+      textAnchor="end"
+      className="text-xs font-medium fill-neutral-900"
+    >
+      {payload.value}
+    </text>
+  );
+}
+
+function FunnelTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: any[];
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+  const value = payload[0].payload.value;
+  return (
+    <div className="rounded-md border bg-white px-2 py-1 text-xs shadow-sm">
+      <p className="font-medium mb-1">{label}</p>
+      <div className="flex items-center gap-2">
+        <span className="h-2 w-2 rounded-full" style={{ backgroundColor: '#a855f7' }} />
+        <span>{value}</span>
+      </div>
+    </div>
+  );
+}
+
+function formatDuration(value: number) {
+  const days = Math.floor(value);
+  const hours = Math.round((value - days) * 24);
+  const dayStr = days > 0 ? `${days}d` : '';
+  const hourStr = hours > 0 ? `${hours}h` : '';
+  return dayStr || hourStr ? [dayStr, hourStr].filter(Boolean).join(' ') : '0h';
+}

--- a/components/recruitment/JobTalentBoard.tsx
+++ b/components/recruitment/JobTalentBoard.tsx
@@ -10,6 +10,7 @@ interface Stage {
   id: string;
   name: string;
   position: number;
+  sla_days?: number | null;
 }
 
 interface Tag {
@@ -25,6 +26,7 @@ interface ApplicationItem {
   created_at: string;
   source: string | null;
   tags: Tag[];
+  status: string;
 }
 
 const DEFAULT_STAGES = [
@@ -50,6 +52,7 @@ export default function JobTalentBoard({ jobId }: Props) {
     talentId: string;
     appId: string;
   } | null>(null);
+  const [statusFilter, setStatusFilter] = useState('active');
 
   const load = async () => {
     const {
@@ -76,11 +79,12 @@ export default function JobTalentBoard({ jobId }: Props) {
         .select('id,name,position');
       stagesData = data || [];
     }
-    setStages(stagesData || []);
+    stagesData = (stagesData || []).sort((a, b) => a.position - b.position);
+    setStages(stagesData);
     const { data: appData } = await supabase
       .from('applications')
       .select(
-        'id,stage_id,talent:talents(id,name,created_at,source,talent_tag_map(tag:talent_tags(name,color)))'
+        'id,stage_id,talent:talents(id,name,created_at,source,status,talent_tag_map(tag:talent_tags(name,color)))'
       )
       .eq('company_id', compId)
       .eq('job_id', jobId);
@@ -97,6 +101,7 @@ export default function JobTalentBoard({ jobId }: Props) {
             name: m.tag.name,
             color: m.tag.color || '#a855f7',
           })) || [],
+        status: a.talent.status,
       })) || [];
     setItems(mapped);
   };
@@ -107,15 +112,17 @@ export default function JobTalentBoard({ jobId }: Props) {
 
   const onDrop = async (stageId: string) => {
     if (!dragId) return;
+    const current = items.find((t) => t.id === dragId);
     console.log('[JobTalentBoard] updating application', {
       id: dragId,
-      stage: stageId,
+      from: current?.stage_id,
+      to: stageId,
     });
     const { data, error } = await supabase
       .from('applications')
       .update({ stage_id: stageId })
       .eq('id', dragId)
-      .select();
+      .select('id');
     if (error) {
       console.error('[JobTalentBoard] update failed', error);
       alert(error.message);
@@ -124,6 +131,27 @@ export default function JobTalentBoard({ jobId }: Props) {
       setItems((prev) =>
         prev.map((t) => (t.id === dragId ? { ...t, stage_id: stageId } : t)),
       );
+      const today = new Date().toISOString().split('T')[0];
+      if (current?.stage_id) {
+        await supabase
+          .from('application_stage_dates')
+          .update({ day_out: today })
+          .eq('application_id', dragId)
+          .eq('stage_id', current.stage_id)
+          .is('day_out', null);
+      }
+      const { data: existingStage } = await supabase
+        .from('application_stage_dates')
+        .select('day_in')
+        .eq('application_id', dragId)
+        .eq('stage_id', stageId)
+        .maybeSingle();
+      await supabase.from('application_stage_dates').upsert({
+        application_id: dragId,
+        stage_id: stageId,
+        day_in: existingStage?.day_in || today,
+        day_out: null,
+      });
     }
     setDragId(null);
   };
@@ -136,10 +164,14 @@ export default function JobTalentBoard({ jobId }: Props) {
     return `${hours}h`;
   };
 
-  const grouped = stages.map((s) => ({
-    stage: s,
-    items: items.filter((t) => t.stage_id === s.id),
-  }));
+  const grouped = [...stages]
+    .sort((a, b) => a.position - b.position)
+    .map((s) => ({
+      stage: s,
+      items: items.filter(
+        (t) => t.stage_id === s.id && t.status === statusFilter
+      ),
+    }));
 
   return (
     <div>
@@ -149,15 +181,40 @@ export default function JobTalentBoard({ jobId }: Props) {
           Etapas
         </Button>
       </div>
+      <div className="mb-4">
+        <div className="flex border-b border-gray-200">
+          {[
+            { value: 'active', label: 'Ativos' },
+            { value: 'withdrawn', label: 'Desistentes' },
+            { value: 'rejected', label: 'Reprovados' },
+          ].map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => setStatusFilter(opt.value)}
+              className={
+                'flex-1 px-4 py-2 text-sm font-medium ' +
+                (statusFilter === opt.value
+                  ? 'border-b-2 border-brand text-brand'
+                  : 'text-gray-500')
+              }
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
       <div className="flex gap-4 overflow-x-auto">
         {grouped.map(({ stage, items }) => (
           <div
             key={stage.id}
-            className="w-64 bg-gray-100 rounded p-2"
+            className="w-64 rounded p-2 bg-purple-50"
             onDragOver={(e) => e.preventDefault()}
             onDrop={() => onDrop(stage.id)}
           >
-            <h3 className="font-medium mb-2">{stage.name}</h3>
+            <div className="mb-2 flex items-center justify-between rounded bg-white px-2 py-1">
+              <h3 className="font-medium">{stage.name}</h3>
+              <span className="text-sm text-gray-600">{items.length}</span>
+            </div>
             {items.map((t) => (
               <div
                 key={t.id}
@@ -229,9 +286,9 @@ export default function JobTalentBoard({ jobId }: Props) {
         open={stageOpen}
         onClose={() => {
           setStageOpen(false);
-          load();
         }}
         jobId={jobId}
+        onOrderChange={setStages}
       />
     </div>
   );

--- a/components/recruitment/TalentModal.tsx
+++ b/components/recruitment/TalentModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { supabase } from '../../lib/supabaseClient';
 import { Button } from '../ui/button';
-import { X, Settings } from 'lucide-react';
+import { X, Settings, ChevronDown } from 'lucide-react';
 import TagSidebar from '../TagSidebar';
 
 interface Tag {
@@ -27,6 +27,7 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
   const [seniority, setSeniority] = useState('');
   const [availability, setAvailability] = useState('');
   const [source, setSource] = useState('');
+  const [status, setStatus] = useState('active');
   const [comment, setComment] = useState('');
   const [tags, setTags] = useState<Tag[]>([]);
   const [newTag, setNewTag] = useState('');
@@ -39,7 +40,7 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
       const { data: talent } = await supabase
         .from('talents')
         .select(
-          'name,email,phone,city,state,cv_url,salary_expectation,seniority,availability,source,comment,talent_tag_map(tag:talent_tags(name,color))'
+          'name,email,phone,city,state,cv_url,salary_expectation,seniority,availability,source,status,comment,talent_tag_map(tag:talent_tags(name,color))'
         )
         .eq('id', talentId)
         .single();
@@ -54,6 +55,7 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
         setSeniority(talent.seniority || '');
         setAvailability(talent.availability || '');
         setSource(talent.source || '');
+        setStatus(talent.status || 'active');
         setComment(talent.comment || '');
         setTags(
           talent.talent_tag_map?.map((m: any) => ({
@@ -119,6 +121,7 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
         seniority,
         availability,
         source,
+        status,
         comment,
       })
       .eq('id', talentId);
@@ -230,11 +233,20 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
           </div>
           <div>
             <label className="block text-sm font-medium mb-1">Senioridade</label>
-            <input
-              className="w-full border p-2 rounded"
-              value={seniority}
-              onChange={(e) => setSeniority(e.target.value)}
-            />
+            <div className="relative">
+              <select
+                className="w-full border p-2 rounded appearance-none pr-8"
+                value={seniority}
+                onChange={(e) => setSeniority(e.target.value)}
+              >
+                <option value="">Selecione</option>
+                <option value="junior">Junior</option>
+                <option value="pleno">Pleno</option>
+                <option value="senior">Senior</option>
+                <option value="especialista">Especialista</option>
+              </select>
+              <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500 pointer-events-none" />
+            </div>
           </div>
           <div>
             <label className="block text-sm font-medium mb-1">Disponibilidade</label>
@@ -246,19 +258,44 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
           </div>
           <div>
             <label className="block text-sm font-medium mb-1">Fonte</label>
-            <select
-              className="w-full border p-2 rounded appearance-none pr-6"
-              value={source}
-              onChange={(e) => setSource(e.target.value)}
-            >
-              <option value="">Selecione</option>
-              <option value="career_site">Site</option>
-              <option value="referral">Indicação</option>
-              <option value="linkedin">LinkedIn</option>
-              <option value="import">Importação</option>
-              <option value="event">Evento</option>
-              <option value="other">Outro</option>
-            </select>
+            <div className="relative">
+              <select
+                className="w-full border p-2 rounded appearance-none pr-8"
+                value={source}
+                onChange={(e) => setSource(e.target.value)}
+              >
+                <option value="">Selecione</option>
+                <option value="career_site">Site</option>
+                <option value="referral">Indicação</option>
+                <option value="linkedin">LinkedIn</option>
+                <option value="import">Importação</option>
+                <option value="event">Evento</option>
+                <option value="other">Outro</option>
+              </select>
+              <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500 pointer-events-none" />
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Status</label>
+            <div className="space-y-2">
+              {[
+                { value: 'active', label: 'Ativo' },
+                { value: 'withdrawn', label: 'Desistente' },
+                { value: 'rejected', label: 'Reprovado' },
+              ].map((opt) => (
+                <label key={opt.value} className="flex items-center gap-2 text-sm">
+                  <input
+                    type="radio"
+                    name="status"
+                    value={opt.value}
+                    checked={status === opt.value}
+                    onChange={(e) => setStatus(e.target.value)}
+                    className="h-4 w-4 accent-brand"
+                  />
+                  {opt.label}
+                </label>
+              ))}
+            </div>
           </div>
           <div className="sm:col-span-2">
             <div className="flex items-center justify-between mb-1">
@@ -284,9 +321,9 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
               ))}
             </div>
             <div className="flex flex-wrap items-center gap-2">
-              <div className="flex-1">
+              <div className="flex-1 relative">
                 <input
-                  className="w-full border p-2 rounded appearance-none"
+                  className="w-full border p-2 rounded appearance-none pr-8"
                   placeholder="Adicionar tag"
                   value={newTag}
                   list="tag-suggestions"
@@ -297,6 +334,7 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
                     setNewColor(found?.color || '#a855f7');
                   }}
                 />
+                <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500 pointer-events-none" />
               </div>
               <datalist id="tag-suggestions">
                 {suggestions.map((s) => (

--- a/docs/recruitment-selection.md
+++ b/docs/recruitment-selection.md
@@ -15,8 +15,10 @@ Principais objetivos:
 - **skills**, **talent_skill_map**: habilidades técnicas ou comportamentais.
 - **jobs**: vagas com status e etapas personalizadas.
 - **job_stages**: etapas padrão por empresa ou sobrescritas por vaga.
+- **job_metrics**: estatísticas agregadas por vaga (ex.: cliques no link).
 - **applications**: vínculo talento↔vaga com estágio atual.
 - **application_stage_history**: histórico de mudanças de etapa e SLAs.
+- **application_stage_dates**: registro das datas de entrada e saída em cada etapa.
 - **application_events**: auditoria de ações (quem, quando, payload).
 - **reports_cache**: materialização periódica de métricas.
 
@@ -26,7 +28,9 @@ Principais objetivos:
 - `applications.job_id -> jobs.id`
 - `applications.talent_id -> talents.id`
 - `job_stages.job_id -> jobs.id` (ou nulo para padrão da empresa)
+- `job_metrics.job_id -> jobs.id`
 - `application_stage_history.application_id -> applications.id`
+- `application_stage_dates.application_id -> applications.id`
 - `application_events.application_id -> applications.id`
 
 ## 3. Script SQL (Supabase)
@@ -37,6 +41,7 @@ create type job_status as enum ('open','closed','frozen');
 create type application_stage as enum ('applied','screening','interview','offer','admitted','rejected','withdrawn');
 create type candidate_source as enum ('career_site','referral','linkedin','import','event','other');
 create type rejection_reason as enum ('lack_of_skill','cultural_fit','salary','position_filled','candidate_withdrew','other');
+create type talent_status as enum ('active','withdrawn','rejected');
 
 -- Talents
 create table talents (
@@ -54,6 +59,7 @@ create table talents (
   seniority text,
   availability text,
   source candidate_source,
+  status talent_status default 'active',
   consent_at timestamptz,
   created_at timestamptz default now(),
   updated_at timestamptz default now(),

--- a/explanation.txt
+++ b/explanation.txt
@@ -1,0 +1,10 @@
+This project counts link clicks using Supabase.
+
+1. **Database schema**
+   - The `job_metrics` table stores a row per job with a `link_clicks` column. A SQL function `increment_job_link_click` inserts or updates this row, adding one to `link_clicks` on each call.
+2. **When a candidate visits the job page**
+   - The public job application page (`pages/apply/[id].tsx`) calls `increment_job_link_click` on every request to record the visit.
+3. **Displaying the total**
+   - The metrics tab fetches the `link_clicks` value from `job_metrics` and shows it as the first bar of the funnel chart (`components/recruitment/JobMetrics.tsx`).
+
+This flow ensures that every time someone clicks the job link, the backend counter increments and the metrics dashboard reflects the updated total.

--- a/pages/api/apply.ts
+++ b/pages/api/apply.ts
@@ -107,6 +107,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(400).json({ error: existingErr.message });
   }
 
+  let appId = existingApp?.id;
   let appError;
   if (existingApp) {
     ({ error: appError } = await supabase
@@ -114,17 +115,39 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       .update({ stage_id: firstStage?.id || null })
       .eq('id', existingApp.id));
   } else {
-    ({ error: appError } = await supabase.from('applications').insert({
-      company_id: job.company_id,
-      job_id,
-      talent_id: talent.id,
-      stage_id: firstStage?.id || null,
-    }));
+    const { data: inserted, error } = await supabase
+      .from('applications')
+      .insert({
+        company_id: job.company_id,
+        job_id,
+        talent_id: talent.id,
+        stage_id: firstStage?.id || null,
+      })
+      .select('id')
+      .single();
+    appError = error;
+    appId = inserted?.id;
   }
 
-  if (appError) {
+  if (appError || !appId) {
     console.error('Application save error', appError);
-    return res.status(400).json({ error: appError.message });
+    return res.status(400).json({ error: appError?.message || 'Erro ao salvar candidatura' });
+  }
+
+  if (firstStage?.id) {
+    const today = new Date().toISOString().split('T')[0];
+    const { data: existingStage } = await supabase
+      .from('application_stage_dates')
+      .select('day_in')
+      .eq('application_id', appId)
+      .eq('stage_id', firstStage.id)
+      .maybeSingle();
+    await supabase.from('application_stage_dates').upsert({
+      application_id: appId,
+      stage_id: firstStage.id,
+      day_in: existingStage?.day_in || today,
+      day_out: null,
+    });
   }
 
   return res.status(200).json({ success: true });

--- a/pages/apply/[id].tsx
+++ b/pages/apply/[id].tsx
@@ -101,5 +101,6 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   if (!job) {
     return { notFound: true };
   }
+  await supabase.rpc('increment_job_link_click', { j: job.id });
   return { props: { job } };
 };

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -50,8 +50,8 @@ export default function Dashboard() {
         .from('companies')
         .select('maxemployees')
         .eq('id', companyId)
-        .single();
-      if (company?.maxemployees === 0) {
+        .maybeSingle();
+      if (company && company.maxemployees === 0) {
         router.replace(`/pending?companyId=${companyId}`);
         return;
       }

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -65,8 +65,8 @@ export default function Login() {
       .from('companies')
       .select('maxemployees')
       .eq('id', companyId)
-      .single();
-    if (company?.maxemployees === 0) {
+      .maybeSingle();
+    if (company && company.maxemployees === 0) {
       router.push(`/pending?companyId=${companyId}`);
     } else {
       router.push('/dashboard');

--- a/pages/recruitment/jobs/[id].tsx
+++ b/pages/recruitment/jobs/[id].tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import Layout from '../../../components/Layout';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../../../components/ui/tabs';
 import JobTalentBoard from '../../../components/recruitment/JobTalentBoard';
+import JobMetrics from '../../../components/recruitment/JobMetrics';
 import { supabase } from '../../../lib/supabaseClient';
 import { Input } from '../../../components/ui/input';
 import { Button } from '../../../components/ui/button';
@@ -573,7 +574,7 @@ export default function JobDetails() {
             )}
           </TabsContent>
           <TabsContent value="metrics">
-            <p>Métricas em construção.</p>
+            {id && !Array.isArray(id) && <JobMetrics jobId={id} />}
           </TabsContent>
           <TabsContent value="ads">
             <div className="space-y-4">

--- a/supabaserecrutamento.sql
+++ b/supabaserecrutamento.sql
@@ -9,6 +9,7 @@ create type job_status as enum ('open','closed','frozen');
 create type application_status as enum ('applied','screening','interview','offer','admitted','rejected','withdrawn');
 create type candidate_source as enum ('career_site','referral','linkedin','import','event','other');
 create type rejection_reason as enum ('lack_of_skill','cultural_fit','salary','position_filled','candidate_withdrew','other');
+create type talent_status as enum ('active','withdrawn','rejected');
 
 -- Talents
 create table if not exists talents (
@@ -27,6 +28,7 @@ create table if not exists talents (
   seniority text,
   availability text,
   source candidate_source,
+  status talent_status default 'active',
   consent_at timestamptz,
   created_at timestamptz default now(),
   updated_at timestamptz default now(),
@@ -102,6 +104,19 @@ create table if not exists job_stages (
   unique (job_id,position)
 );
 
+create table if not exists job_metrics (
+  job_id uuid primary key references jobs(id) on delete cascade,
+  link_clicks int default 0
+);
+
+create or replace function increment_job_link_click(j uuid)
+returns void as $$
+  insert into job_metrics(job_id, link_clicks)
+  values (j, 1)
+  on conflict (job_id)
+    do update set link_clicks = job_metrics.link_clicks + 1;
+$$ language sql;
+
 -- Applications
 create table if not exists applications (
   id uuid primary key default uuid_generate_v4(),
@@ -130,6 +145,14 @@ create table if not exists application_stage_history (
   note text,
   due_at timestamptz,
   breached_at timestamptz
+);
+
+create table if not exists application_stage_dates (
+  application_id uuid not null references applications(id) on delete cascade,
+  stage_id uuid not null references job_stages(id) on delete cascade,
+  day_in date not null,
+  day_out date,
+  primary key (application_id, stage_id)
 );
 
 create table if not exists application_events (
@@ -162,6 +185,7 @@ alter table jobs enable row level security;
 alter table job_stages enable row level security;
 alter table applications enable row level security;
 alter table application_stage_history enable row level security;
+alter table application_stage_dates enable row level security;
 alter table application_events enable row level security;
 alter table reports_cache enable row level security;
 
@@ -173,6 +197,7 @@ create policy company_iso on jobs using (company_id = (auth.jwt() ->> 'company_i
 create policy company_iso on job_stages using (company_id = (auth.jwt() ->> 'company_id')::uuid) with check (company_id = (auth.jwt() ->> 'company_id')::uuid);
 create policy company_iso on applications using (company_id = (auth.jwt() ->> 'company_id')::uuid) with check (company_id = (auth.jwt() ->> 'company_id')::uuid);
 create policy company_iso on application_stage_history using (exists (select 1 from applications a where a.id = application_stage_history.application_id and a.company_id = (auth.jwt() ->> 'company_id')::uuid));
+create policy company_iso on application_stage_dates using (exists (select 1 from applications a where a.id = application_stage_dates.application_id and a.company_id = (auth.jwt() ->> 'company_id')::uuid));
 create policy company_iso on application_events using (company_id = (auth.jwt() ->> 'company_id')::uuid) with check (company_id = (auth.jwt() ->> 'company_id')::uuid);
 create policy company_iso on reports_cache using (company_id = (auth.jwt() ->> 'company_id')::uuid) with check (company_id = (auth.jwt() ->> 'company_id')::uuid);
 


### PR DESCRIPTION
## Summary
- center duration text in Tempo metrics card and push radar chart labels further outward
- render candidate funnel chart inside a card and add PNG download button for metrics tab
- add `status` column and enum for talents
- filter talents in job board by status with Ativos/Desistentes/Reprovados tabs
- allow updating a talent's status from the talent detail modal using radio buttons
- style status filter tabs to match main recruitment top bar and simplify modal status selection
- enhance talent modal with purple-accent status radios, dropdown arrows, and a seniority selector
- track job link clicks in new `job_metrics` table and expose an increment function
- increment link click count on public job page and render funnel chart of clicks and stage counts on Metrics tab
- center funnel bars around a middle axis so each stage's bar is symmetrically indented
- add "Funil de candidatos" heading, display totals inside each funnel bar, and show stage labels beside their bars
- skip funnel stages with zero counts and guard against missing job metrics data
- align the funnel title with the chart's central axis and style stage labels with purple badges
- keep stage legend outside funnel bars so labels no longer overlap counts
- render funnel stage legend beside the chart to prevent overlap with funnel bars
- align funnel labels directly with their bars by rendering them as custom Y-axis ticks
- left-align funnel legend text and remove purple bullet icons
- widen job metrics card for improved visibility
- add time metrics card with average time-to-fill, per-stage durations, and SLA compliance
- track stage entry/exit dates for each application and update funnel metrics accordingly
- combine time metrics into a single card showing time-to-fill and SLA compliance side by side with per-stage averages below
- divide the Tempo section into three nested cards for time-to-fill, SLA compliance, and per-stage averages
- show per-stage averages outside the radar chart with download option and formatted day/hour durations
- abbreviate stage duration labels to "Xd Yh" and offset radar ticks so text stays outside the chart
- keep funnel stage labels from overlapping bars by anchoring Y-axis ticks to the left
- adjust funnel legend offset so labels no longer overlap the chart
- push radar chart labels outward with extra margin so "Tempo médio em cada etapa" text stays outside the graph
- expand radar chart margins and increase tick offset so centered stage labels never collide with the radar plot
- retain full radar chart scale while spacing labels further from the chart
- reorder job stages with drag-and-drop and automatically persist sequential positions to avoid 409 conflicts
- log and update stage ordering changes one row at a time to debug failed reorders
- move stage positions to temporary negative values before assigning final order to eliminate unique-key conflicts and log each update
- order talent columns by stage position
- immediately sync talent board column order when stages are reordered
- **preserve stage order after closing the sidebar by avoiding a redundant reload and broadcasting edits to the parent board**
- style stage columns with white headers showing stage name and count and a light purple background for cards

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ac63d41c88832dae428256b68eda1c