### PR TITLE
feat: add talent status filter, job metrics funnel, and custom form fields

### DIFF
--- a/components/StageSidebar.tsx
+++ b/components/StageSidebar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { GripVertical } from 'lucide-react';
 import { supabase } from '../lib/supabaseClient';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
@@ -14,13 +15,15 @@ interface Props {
   open: boolean;
   onClose: () => void;
   jobId?: string;
+  onOrderChange?: (stages: Stage[]) => void;
 }
 
-export default function StageSidebar({ open, onClose, jobId }: Props) {
+export default function StageSidebar({ open, onClose, jobId, onOrderChange }: Props) {
   const [stages, setStages] = useState<Stage[]>([]);
   const [companyId, setCompanyId] = useState('');
   const [name, setName] = useState('');
   const [sla, setSla] = useState('');
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -42,24 +45,55 @@ export default function StageSidebar({ open, onClose, jobId }: Props) {
       if (jobId) query.eq('job_id', jobId); else query.is('job_id', null);
       const { data } = await query;
       setStages(data || []);
+      onOrderChange?.((data || []).sort((a, b) => a.position - b.position));
     };
     load();
-  }, [open]);
+  }, [open, onOrderChange]);
+
+  const persistOrder = async (list: Stage[]) => {
+    const ordered = list.map((s, i) => ({ ...s, position: i + 1 }));
+    setStages(ordered);
+    onOrderChange?.(ordered);
+    console.log('persistOrder start ->', ordered.map(({ id, position }) => ({ id, position })));
+    try {
+      // First move everything to a unique negative position to avoid conflicts
+      for (const { id, position } of ordered) {
+        const tempPos = -(position + 1000);
+        const { error } = await supabase
+          .from('job_stages')
+          .update({ position: tempPos })
+          .eq('id', id);
+        console.log('temp update', { id, tempPos, error });
+      }
+
+      // Then apply the final sequential positions
+      for (const { id, position } of ordered) {
+        const { error } = await supabase
+          .from('job_stages')
+          .update({ position })
+          .eq('id', id);
+        console.log('final update', { id, position, error });
+      }
+    } catch (err) {
+      console.error('persistOrder failed', err);
+    }
+  };
 
   const add = async () => {
+    const nextPos = stages.reduce((max, s) => Math.max(max, s.position), 0) + 1;
     const { data, error } = await supabase
       .from('job_stages')
       .insert({
         company_id: companyId,
         job_id: jobId ?? null,
         name,
-        position: stages.length + 1,
+        position: nextPos,
         sla_days: sla ? Number(sla) : null,
       })
       .select('id,name,position,sla_days')
       .single();
     if (!error && data) {
-      setStages([...stages, data]);
+      await persistOrder([...stages, data]);
       setName('');
       setSla('');
     }
@@ -68,13 +102,36 @@ export default function StageSidebar({ open, onClose, jobId }: Props) {
   const save = async (stage: Stage) => {
     await supabase
       .from('job_stages')
-      .update({ name: stage.name, position: stage.position, sla_days: stage.sla_days })
+      .update({ name: stage.name, sla_days: stage.sla_days })
       .eq('id', stage.id);
+    setStages((prev) => [...prev]);
+    onOrderChange?.(
+      [...stages].sort((a, b) => a.position - b.position)
+    );
   };
 
   const remove = async (id: string) => {
     await supabase.from('job_stages').delete().eq('id', id);
-    setStages(stages.filter((s) => s.id !== id));
+    await persistOrder(stages.filter((s) => s.id !== id));
+  };
+
+  const handleDragStart = (index: number) => setDragIndex(index);
+
+  const handleDragOver = (index: number, e: React.DragEvent) => {
+    e.preventDefault();
+    if (dragIndex === null || dragIndex === index) return;
+    const updated = [...stages];
+    const [moved] = updated.splice(dragIndex, 1);
+    updated.splice(index, 0, moved);
+    setDragIndex(index);
+    setStages(updated);
+  };
+
+  const handleDragEnd = () => {
+    if (dragIndex === null) return;
+    console.log('handleDragEnd ->', stages.map(({ id, position }) => ({ id, position })));
+    persistOrder(stages);
+    setDragIndex(null);
   };
 
   if (!open) return null;
@@ -106,15 +163,16 @@ export default function StageSidebar({ open, onClose, jobId }: Props) {
             </Button>
           </div>
         </div>
-        {stages.map((st) => (
-          <div key={st.id} className="grid grid-cols-6 gap-2 mb-2 items-center">
-            <Input
-              value={st.position}
-              type="number"
-              onChange={(e) => (st.position = Number(e.target.value))}
-              onBlur={() => save(st)}
-              className="col-span-1"
-            />
+        {stages.map((st, i) => (
+          <div
+            key={st.id}
+            className="grid grid-cols-6 gap-2 mb-2 items-center cursor-move"
+            draggable
+            onDragStart={() => handleDragStart(i)}
+            onDragOver={(e) => handleDragOver(i, e)}
+            onDragEnd={handleDragEnd}
+          >
+            <GripVertical className="col-span-1 h-4 w-4 justify-self-center" />
             <Input
               value={st.name}
               onChange={(e) => (st.name = e.target.value)}

--- a/components/recruitment/JobMetrics.tsx
+++ b/components/recruitment/JobMetrics.tsx
@@ -1,0 +1,427 @@
+import { useEffect, useState, useRef } from 'react';
+import { supabase } from '../../lib/supabaseClient';
+import { ChartContainer } from '../ui/chart';
+import { Card } from '../ui/card';
+import { Button } from '../ui/button';
+import { Download } from 'lucide-react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  LabelList,
+  RadarChart,
+  Radar,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+} from 'recharts';
+
+interface Props {
+  jobId: string;
+}
+
+const CHART_MARGIN = { left: 20, right: 20 };
+const Y_AXIS_WIDTH = 180;
+
+export default function JobMetrics({ jobId }: Props) {
+  const [data, setData] = useState<
+    { name: string; half: number; value: number }[]
+  >([]);
+  const [maxHalf, setMaxHalf] = useState(0);
+  const [timeToFill, setTimeToFill] = useState(0);
+  const [stageDurations, setStageDurations] = useState<
+    { name: string; avg: number; sla: number }[]
+  >([]);
+  const chartRef = useRef<HTMLDivElement>(null);
+  const radarRef = useRef<HTMLDivElement>(null);
+
+  const handleDownload = () => {
+    if (!chartRef.current) return;
+    const svg = chartRef.current.querySelector('svg');
+    if (!svg) return;
+    const serializer = new XMLSerializer();
+    const svgStr = serializer.serializeToString(svg);
+    const canvas = document.createElement('canvas');
+    canvas.width = svg.clientWidth;
+    canvas.height = svg.clientHeight;
+    const ctx = canvas.getContext('2d');
+    const img = new Image();
+    const blob = new Blob([svgStr], { type: 'image/svg+xml;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    img.onload = () => {
+      ctx?.drawImage(img, 0, 0);
+      URL.revokeObjectURL(url);
+      const a = document.createElement('a');
+      a.download = 'funil-de-candidatos.png';
+      a.href = canvas.toDataURL('image/png');
+      a.click();
+    };
+    img.src = url;
+  };
+
+  const handleDownloadRadar = () => {
+    if (!radarRef.current) return;
+    const svg = radarRef.current.querySelector('svg');
+    if (!svg) return;
+    const serializer = new XMLSerializer();
+    const svgStr = serializer.serializeToString(svg);
+    const canvas = document.createElement('canvas');
+    canvas.width = svg.clientWidth;
+    canvas.height = svg.clientHeight;
+    const ctx = canvas.getContext('2d');
+    const img = new Image();
+    const blob = new Blob([svgStr], { type: 'image/svg+xml;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    img.onload = () => {
+      ctx?.drawImage(img, 0, 0);
+      URL.revokeObjectURL(url);
+      const a = document.createElement('a');
+      a.download = 'tempo-medio-etapas.png';
+      a.href = canvas.toDataURL('image/png');
+      a.click();
+    };
+    img.src = url;
+  };
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const { data: stages } = await supabase
+          .from('job_stages')
+          .select('id,name,position,sla_days')
+          .eq('job_id', jobId)
+          .order('position');
+
+        const { data: apps } = await supabase
+          .from('applications')
+          .select('id,stage_id,applied_at')
+          .eq('job_id', jobId);
+
+        const counts: Record<string, number> = {};
+        (apps || []).forEach((a) => {
+          const key = a.stage_id || 'none';
+          counts[key] = (counts[key] || 0) + 1;
+        });
+
+        const appIds = (apps || []).map((a) => a.id);
+        const { data: dateRows } = await supabase
+          .from('application_stage_dates')
+          .select('application_id,stage_id,day_in,day_out')
+          .in('application_id', appIds);
+
+        const stageMap = new Map(
+          (stages || []).map((s) => [s.id, { name: s.name, sla: s.sla_days }])
+        );
+
+        const datesByApp: Record<string, any[]> = {};
+        (dateRows || []).forEach((d) => {
+          if (!datesByApp[d.application_id]) datesByApp[d.application_id] = [];
+          datesByApp[d.application_id].push(d);
+        });
+
+        let totalFill = 0;
+        let fillCount = 0;
+        const stats: Record<string, { total: number; count: number; slaHits: number; slaTotal: number }> = {};
+
+        Object.entries(datesByApp).forEach(([appId, records]) => {
+          const ins = records.map((r: any) => new Date(r.day_in).getTime());
+          const outs = records
+            .map((r: any) => (r.day_out ? new Date(r.day_out).getTime() : null))
+            .filter((t: number | null): t is number => t !== null);
+          if (ins.length && outs.length) {
+            const first = Math.min(...ins);
+            const last = Math.max(...outs);
+            totalFill += (last - first) / 86400000;
+            fillCount++;
+          }
+          records.forEach((r: any) => {
+            if (!r.day_in) return;
+            const start = new Date(r.day_in).getTime();
+            const end = r.day_out ? new Date(r.day_out).getTime() : Date.now();
+            const duration = (end - start) / 86400000;
+            const st = stats[r.stage_id] || {
+              total: 0,
+              count: 0,
+              slaHits: 0,
+              slaTotal: 0,
+            };
+            st.total += duration;
+            st.count++;
+            const sla = stageMap.get(r.stage_id)?.sla;
+            if (sla) {
+              st.slaTotal++;
+              if (duration <= sla) st.slaHits++;
+            }
+            stats[r.stage_id] = st;
+          });
+        });
+
+        setTimeToFill(fillCount ? totalFill / fillCount : 0);
+        const durationArr = Object.entries(stats).map(([id, s]) => ({
+          name: stageMap.get(id)?.name || 'Etapa',
+          avg: s.count ? s.total / s.count : 0,
+          sla: s.slaTotal ? (s.slaHits / s.slaTotal) * 100 : 0,
+        }));
+        setStageDurations(durationArr);
+
+        const { data: metric, error: metricError } = await supabase
+          .from('job_metrics')
+          .select('link_clicks')
+          .eq('job_id', jobId)
+          .maybeSingle();
+
+        const clicks = metricError ? 0 : metric?.link_clicks || 0;
+
+        const stageData = (stages || [])
+          .map((s) => ({ name: s.name, value: counts[s.id] || 0 }));
+
+        for (let i = stageData.length - 1; i >= 0; i--) {
+          const next = i < stageData.length - 1 ? stageData[i + 1].value : 0;
+          stageData[i].value += next;
+        }
+
+        const filteredStages = stageData.filter((d) => d.value > 0);
+
+        const rawData = [
+          { name: 'Cliques no link', value: clicks },
+          ...filteredStages,
+        ].filter((d) => d.value > 0);
+
+        const chartData = rawData.map((d) => ({
+          name: d.name,
+          half: d.value / 2,
+          value: d.value,
+        }));
+
+        setData(chartData);
+        const maxVal = rawData.reduce((m, d) => Math.max(m, d.value), 0);
+        setMaxHalf(maxVal / 2);
+      } catch (e) {
+        console.error('Failed to load job metrics', e);
+      }
+    };
+    load();
+  }, [jobId]);
+
+  const radarData = stageDurations.map((s) => ({ stage: s.name, value: s.avg }));
+  const maxAvg = radarData.reduce((m, d) => Math.max(m, d.value), 0);
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <Card>
+        <div className="flex items-center justify-between p-4 pb-0">
+          <h2 className="font-semibold">Funil de candidatos</h2>
+          <Button variant="outline" size="sm" onClick={handleDownload}>
+            <Download className="h-4 w-4" />
+          </Button>
+        </div>
+        <ChartContainer ref={chartRef} className="mt-4">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={data} layout="vertical" margin={CHART_MARGIN}>
+              <XAxis
+                type="number"
+                domain={[-maxHalf, maxHalf]}
+                hide
+                axisLine={false}
+                tickLine={false}
+              />
+              <YAxis
+                dataKey="name"
+                type="category"
+                axisLine={false}
+                tickLine={false}
+                width={Y_AXIS_WIDTH}
+                tick={(props) => <StageTick {...props} />}
+              />
+              <Tooltip content={<FunnelTooltip />} />
+              <Bar
+                dataKey="half"
+                barSize={48}
+                shape={(props) => <CenteredBar {...props} />}
+              >
+                <LabelList
+                  dataKey="value"
+                  content={(props) => <CenteredValue {...props} />}
+                />
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartContainer>
+      </Card>
+      <Card>
+        <div className="p-4">
+          <h2 className="font-semibold mb-4">Tempo</h2>
+          <div className="grid gap-4 md:grid-cols-2">
+            <Card>
+              <div className="p-4">
+                <h3 className="font-medium">Tempo médio para preencher vaga</h3>
+                <p className="text-2xl font-semibold text-center">
+                  {formatDuration(timeToFill)}
+                </p>
+              </div>
+            </Card>
+            <Card>
+              <div className="p-4">
+                <h3 className="font-medium">SLA compliance</h3>
+                {stageDurations.length ? (
+                  <ul className="ml-4 list-disc text-sm">
+                    {stageDurations.map((s) => (
+                      <li key={s.name}>{`${s.name}: ${s.sla.toFixed(0)}%`}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-sm">Sem dados</p>
+                )}
+              </div>
+            </Card>
+            <Card className="md:col-span-2">
+              <div className="flex items-center justify-between p-4 pb-0">
+                <h3 className="font-medium">Tempo médio em cada etapa</h3>
+                <Button variant="outline" size="sm" onClick={handleDownloadRadar}>
+                  <Download className="h-4 w-4" />
+                </Button>
+              </div>
+              {radarData.length ? (
+                <ChartContainer
+                  ref={radarRef}
+                  className="mx-auto aspect-square max-h-[350px] mt-4"
+                >
+                  <ResponsiveContainer width="100%" height="100%">
+                    <RadarChart
+                      data={radarData}
+                      outerRadius={120}
+                      margin={{ top: 40, right: 40, bottom: 40, left: 40 }}
+                    >
+                      <PolarGrid />
+                      <PolarAngleAxis
+                        dataKey="stage"
+                        tick={({ x, y, payload, cx, cy, index }: any) => {
+                          const d = radarData.find((r) => r.stage === payload.value);
+                          const dx = x - cx;
+                          const dy = y - cy;
+                          const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+                          const offset = 30;
+                          const newX = cx + (dx / dist) * (dist + offset);
+                          const newY = cy + (dy / dist) * (dist + offset);
+                          return (
+                            <text
+                              x={newX}
+                              y={newY}
+                              textAnchor="middle"
+                              fontSize={12}
+                              fontWeight={500}
+                            >
+                              <tspan x={newX}>{payload.value}</tspan>
+                              <tspan
+                                x={newX}
+                                dy="1rem"
+                                fontSize={12}
+                                className="fill-muted-foreground"
+                              >
+                                {d ? formatDuration(d.value) : ''}
+                              </tspan>
+                            </text>
+                          );
+                        }}
+                      />
+                      <PolarRadiusAxis domain={[0, maxAvg]} tick={false} />
+                      <Radar
+                        dataKey="value"
+                        stroke="#a855f7"
+                        fill="#a855f7"
+                        fillOpacity={0.6}
+                      />
+                    </RadarChart>
+                  </ResponsiveContainer>
+                </ChartContainer>
+              ) : (
+                <p className="text-sm text-center">Sem dados</p>
+              )}
+            </Card>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function CenteredBar({ x, y, width, height }: any) {
+  const halfWidth = width;
+  return (
+    <rect
+      x={x - halfWidth}
+      y={y}
+      width={halfWidth * 2}
+      height={height}
+      fill="#a855f7"
+      rx={2}
+      ry={2}
+    />
+  );
+}
+
+function CenteredValue({ value, viewBox }: any) {
+  if (value == null || !viewBox) return null;
+  const { x, y, height } = viewBox;
+  const centerX = x;
+  const centerY = y + height / 2;
+  return (
+    <text
+      x={centerX}
+      y={centerY}
+      textAnchor="middle"
+      dominantBaseline="middle"
+      fill="white"
+      className="text-xs font-medium"
+    >
+      {value}
+    </text>
+  );
+}
+
+function StageTick({ x, y, payload }: any) {
+  return (
+    <text
+      x={x - 16}
+      y={y}
+      dy={4}
+      textAnchor="end"
+      className="text-xs font-medium fill-neutral-900"
+    >
+      {payload.value}
+    </text>
+  );
+}
+
+function FunnelTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: any[];
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+  const value = payload[0].payload.value;
+  return (
+    <div className="rounded-md border bg-white px-2 py-1 text-xs shadow-sm">
+      <p className="font-medium mb-1">{label}</p>
+      <div className="flex items-center gap-2">
+        <span className="h-2 w-2 rounded-full" style={{ backgroundColor: '#a855f7' }} />
+        <span>{value}</span>
+      </div>
+    </div>
+  );
+}
+
+function formatDuration(value: number) {
+  const days = Math.floor(value);
+  const hours = Math.round((value - days) * 24);
+  const dayStr = days > 0 ? `${days}d` : '';
+  const hourStr = hours > 0 ? `${hours}h` : '';
+  return dayStr || hourStr ? [dayStr, hourStr].filter(Boolean).join(' ') : '0h';
+}

--- a/components/recruitment/JobTalentBoard.tsx
+++ b/components/recruitment/JobTalentBoard.tsx
@@ -10,6 +10,7 @@ interface Stage {
   id: string;
   name: string;
   position: number;
+  sla_days?: number | null;
 }
 
 interface Tag {
@@ -25,6 +26,7 @@ interface ApplicationItem {
   created_at: string;
   source: string | null;
   tags: Tag[];
+  status: string;
 }
 
 const DEFAULT_STAGES = [
@@ -50,6 +52,7 @@ export default function JobTalentBoard({ jobId }: Props) {
     talentId: string;
     appId: string;
   } | null>(null);
+  const [statusFilter, setStatusFilter] = useState('active');
 
   const load = async () => {
     const {
@@ -76,11 +79,12 @@ export default function JobTalentBoard({ jobId }: Props) {
         .select('id,name,position');
       stagesData = data || [];
     }
-    setStages(stagesData || []);
+    stagesData = (stagesData || []).sort((a, b) => a.position - b.position);
+    setStages(stagesData);
     const { data: appData } = await supabase
       .from('applications')
       .select(
-        'id,stage_id,talent:talents(id,name,created_at,source,talent_tag_map(tag:talent_tags(name,color)))'
+        'id,stage_id,talent:talents(id,name,created_at,source,status,talent_tag_map(tag:talent_tags(name,color)))'
       )
       .eq('company_id', compId)
       .eq('job_id', jobId);
@@ -97,6 +101,7 @@ export default function JobTalentBoard({ jobId }: Props) {
             name: m.tag.name,
             color: m.tag.color || '#a855f7',
           })) || [],
+        status: a.talent.status,
       })) || [];
     setItems(mapped);
   };
@@ -107,15 +112,17 @@ export default function JobTalentBoard({ jobId }: Props) {
 
   const onDrop = async (stageId: string) => {
     if (!dragId) return;
+    const current = items.find((t) => t.id === dragId);
     console.log('[JobTalentBoard] updating application', {
       id: dragId,
-      stage: stageId,
+      from: current?.stage_id,
+      to: stageId,
     });
     const { data, error } = await supabase
       .from('applications')
       .update({ stage_id: stageId })
       .eq('id', dragId)
-      .select();
+      .select('id');
     if (error) {
       console.error('[JobTalentBoard] update failed', error);
       alert(error.message);
@@ -124,6 +131,27 @@ export default function JobTalentBoard({ jobId }: Props) {
       setItems((prev) =>
         prev.map((t) => (t.id === dragId ? { ...t, stage_id: stageId } : t)),
       );
+      const today = new Date().toISOString().split('T')[0];
+      if (current?.stage_id) {
+        await supabase
+          .from('application_stage_dates')
+          .update({ day_out: today })
+          .eq('application_id', dragId)
+          .eq('stage_id', current.stage_id)
+          .is('day_out', null);
+      }
+      const { data: existingStage } = await supabase
+        .from('application_stage_dates')
+        .select('day_in')
+        .eq('application_id', dragId)
+        .eq('stage_id', stageId)
+        .maybeSingle();
+      await supabase.from('application_stage_dates').upsert({
+        application_id: dragId,
+        stage_id: stageId,
+        day_in: existingStage?.day_in || today,
+        day_out: null,
+      });
     }
     setDragId(null);
   };
@@ -136,10 +164,14 @@ export default function JobTalentBoard({ jobId }: Props) {
     return `${hours}h`;
   };
 
-  const grouped = stages.map((s) => ({
-    stage: s,
-    items: items.filter((t) => t.stage_id === s.id),
-  }));
+  const grouped = [...stages]
+    .sort((a, b) => a.position - b.position)
+    .map((s) => ({
+      stage: s,
+      items: items.filter(
+        (t) => t.stage_id === s.id && t.status === statusFilter
+      ),
+    }));
 
   return (
     <div>
@@ -149,68 +181,100 @@ export default function JobTalentBoard({ jobId }: Props) {
           Etapas
         </Button>
       </div>
-      <div className="flex gap-4 overflow-x-auto">
+      <div className="mb-4">
+        <div className="flex border-b border-gray-200">
+          {[
+            { value: 'active', label: 'Ativos' },
+            { value: 'withdrawn', label: 'Desistentes' },
+            { value: 'rejected', label: 'Reprovados' },
+          ].map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => setStatusFilter(opt.value)}
+              className={
+                'flex-1 px-4 py-2 text-sm font-medium ' +
+                (statusFilter === opt.value
+                  ? 'border-b-2 border-brand text-brand'
+                  : 'text-gray-500')
+              }
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div
+        className="grid gap-4"
+        style={{ gridTemplateColumns: `repeat(${grouped.length}, minmax(0, 1fr))` }}
+      >
         {grouped.map(({ stage, items }) => (
           <div
             key={stage.id}
-            className="w-64 bg-gray-100 rounded p-2"
+            className="rounded overflow-hidden flex flex-col"
             onDragOver={(e) => e.preventDefault()}
             onDrop={() => onDrop(stage.id)}
           >
-            <h3 className="font-medium mb-2">{stage.name}</h3>
-            {items.map((t) => (
-              <div
-                key={t.id}
-                className="bg-white rounded shadow p-2 mb-2 cursor-move"
-                draggable
-                onDragStart={() => setDragId(t.id)}
-              >
-                <div className="flex justify-between text-xs text-gray-500">
-                  <span className="flex items-center">
-                    <Clock className="w-3 h-3 mr-1" />
-                    {timeSince(t.created_at)}
-                  </span>
-                  {t.source && <span>{getSourceLabel(t.source)}</span>}
-                </div>
-                <button
-                  className="mt-1 block font-medium hover:underline text-left"
-                  onClick={() =>
-                    setActive({ talentId: t.talent_id, appId: t.id })
-                  }
+            <div className="flex items-center justify-between bg-white px-2 py-2 border-b border-purple-200">
+              <h3 className="font-medium">{stage.name}</h3>
+              <span className="px-2 py-0.5 border border-purple-300 rounded text-sm text-black">
+                {items.length}
+              </span>
+            </div>
+            <div className="bg-purple-50 p-2 flex-1">
+              {items.map((t) => (
+                <div
+                  key={t.id}
+                  className="bg-white rounded shadow p-2 mb-2 cursor-move"
+                  draggable
+                  onDragStart={() => setDragId(t.id)}
                 >
-                  {t.name}
-                </button>
-                {t.tags.length > 0 && (
-                  <div className="mt-1 flex flex-wrap gap-1">
-                    {(() => {
-                      const MAX = 2;
-                      const shown = t.tags.slice(0, MAX);
-                      const extra = t.tags.length - shown.length;
-                      return (
-                        <>
-                          {shown.map((tag) => (
-                            <span
-                              key={tag.name}
-                              className="px-2 py-0.5 rounded text-xs"
-                              style={{
-                                color: tag.color,
-                                backgroundColor: `${tag.color}33`,
-                                fontWeight: 'bold',
-                              }}
-                            >
-                              {tag.name}
-                            </span>
-                          ))}
-                          {extra > 0 && (
-                            <span className="px-2 py-0.5 rounded bg-gray-200 text-xs">+{extra}</span>
-                          )}
-                        </>
-                      );
-                    })()}
+                  <div className="flex justify-between text-xs text-gray-500">
+                    <span className="flex items-center">
+                      <Clock className="w-3 h-3 mr-1" />
+                      {timeSince(t.created_at)}
+                    </span>
+                    {t.source && <span>{getSourceLabel(t.source)}</span>}
                   </div>
-                )}
-              </div>
-            ))}
+                  <button
+                    className="mt-1 block font-medium hover:underline text-left"
+                    onClick={() =>
+                      setActive({ talentId: t.talent_id, appId: t.id })
+                    }
+                  >
+                    {t.name}
+                  </button>
+                  {t.tags.length > 0 && (
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {(() => {
+                        const MAX = 2;
+                        const shown = t.tags.slice(0, MAX);
+                        const extra = t.tags.length - shown.length;
+                        return (
+                          <>
+                            {shown.map((tag) => (
+                              <span
+                                key={tag.name}
+                                className="px-2 py-0.5 rounded text-xs"
+                                style={{
+                                  color: tag.color,
+                                  backgroundColor: `${tag.color}33`,
+                                  fontWeight: 'bold',
+                                }}
+                              >
+                                {tag.name}
+                              </span>
+                            ))}
+                            {extra > 0 && (
+                              <span className="px-2 py-0.5 rounded bg-gray-200 text-xs">+{extra}</span>
+                            )}
+                          </>
+                        );
+                      })()}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
           </div>
         ))}
       </div>
@@ -229,9 +293,9 @@ export default function JobTalentBoard({ jobId }: Props) {
         open={stageOpen}
         onClose={() => {
           setStageOpen(false);
-          load();
         }}
         jobId={jobId}
+        onOrderChange={setStages}
       />
     </div>
   );

--- a/components/recruitment/RoteiroTab.tsx
+++ b/components/recruitment/RoteiroTab.tsx
@@ -1,0 +1,350 @@
+import { useEffect, useRef, useState } from 'react'
+import { createClient } from '@supabase/supabase-js'
+import { Input } from '../ui/input'
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card'
+import {
+  X,
+  Plus,
+  Bold,
+  Italic,
+  Underline,
+  Strikethrough,
+  List,
+  ListOrdered,
+  Heading1,
+  Heading2,
+  Heading3,
+} from 'lucide-react'
+
+export default function RoteiroTab({ jobId }: { jobId: string }) {
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  )
+
+  interface Script {
+    id: string
+    name: string
+    content: string
+    softskills: string[]
+    cultural_fit: string[]
+  }
+
+  const [scripts, setScripts] = useState<Script[]>([])
+  const [currentId, setCurrentId] = useState<string | null>(null)
+  const [name, setName] = useState('')
+  const editorRef = useRef<HTMLDivElement>(null)
+  const [softskills, setSoftskills] = useState<string[]>([])
+  const [fits, setFits] = useState<string[]>([])
+  const [showSidebar, setShowSidebar] = useState<null | 'soft' | 'fit'>(null)
+  const [criterion, setCriterion] = useState('')
+
+  const [formats, setFormats] = useState({
+    bold: false,
+    italic: false,
+    underline: false,
+    strike: false,
+    unordered: false,
+    ordered: false,
+    h1: false,
+    h2: false,
+    h3: false,
+  })
+
+  function updateToolbar() {
+    setFormats({
+      bold: document.queryCommandState('bold'),
+      italic: document.queryCommandState('italic'),
+      underline: document.queryCommandState('underline'),
+      strike: document.queryCommandState('strikeThrough'),
+      unordered: document.queryCommandState('insertUnorderedList'),
+      ordered: document.queryCommandState('insertOrderedList'),
+      h1: document.queryCommandValue('formatBlock') === 'h1',
+      h2: document.queryCommandValue('formatBlock') === 'h2',
+      h3: document.queryCommandValue('formatBlock') === 'h3',
+    })
+  }
+
+  useEffect(() => {
+    document.addEventListener('selectionchange', updateToolbar)
+    return () => document.removeEventListener('selectionchange', updateToolbar)
+  }, [])
+
+  useEffect(() => {
+    loadScripts()
+  }, [jobId])
+
+  async function loadScripts() {
+    const { data } = await supabase
+      .from('job_scripts')
+      .select('id,name,content,softskills,cultural_fit')
+      .eq('job_id', jobId)
+    if (data) {
+      setScripts(data)
+      if (data.length) {
+        const s = data[0]
+        setCurrentId(s.id)
+        setName(s.name)
+        if (editorRef.current) editorRef.current.innerHTML = s.content || ''
+        setSoftskills(s.softskills || [])
+        setFits(s.cultural_fit || [])
+        updateToolbar()
+      }
+    }
+  }
+
+  function selectScript(id: string) {
+    const s = scripts.find((sc) => sc.id === id)
+    if (!s) return
+    setCurrentId(s.id)
+    setName(s.name)
+    if (editorRef.current) editorRef.current.innerHTML = s.content || ''
+    setSoftskills(s.softskills || [])
+    setFits(s.cultural_fit || [])
+    updateToolbar()
+  }
+
+  async function save() {
+    const content = editorRef.current?.innerHTML || ''
+    const { data } = await supabase
+      .from('job_scripts')
+      .upsert({
+        id: currentId || undefined,
+        job_id: jobId,
+        name,
+        content,
+        softskills,
+        cultural_fit: fits,
+      })
+      .select()
+      .single()
+    if (data) {
+      setCurrentId(data.id)
+      loadScripts()
+    }
+  }
+
+  function exec(cmd: string, value?: string) {
+    document.execCommand(cmd, false, value)
+    updateToolbar()
+  }
+
+  function addCriterion() {
+    if (!criterion.trim()) return
+    if (showSidebar === 'soft') {
+      setSoftskills([...softskills, criterion.trim()])
+    } else if (showSidebar === 'fit') {
+      setFits([...fits, criterion.trim()])
+    }
+    setCriterion('')
+    setShowSidebar(null)
+  }
+
+  function removeItem(idx: number, type: 'soft' | 'fit') {
+    if (type === 'soft') {
+      setSoftskills(softskills.filter((_, i) => i !== idx))
+    } else {
+      setFits(fits.filter((_, i) => i !== idx))
+    }
+  }
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-4">
+        <Input
+          placeholder="Nome do roteiro"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="flex-1"
+        />
+        <select
+          className="border p-2 rounded"
+          value={currentId || ''}
+          onChange={(e) => selectScript(e.target.value)}
+        >
+          <option value="">Carregar roteiro...</option>
+          {scripts.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))}
+        </select>
+        <button
+          onClick={save}
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+        >
+          Salvar roteiro
+        </button>
+      </div>
+      <div className="grid md:grid-cols-2 gap-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Roteiro</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap gap-2 mb-2">
+              <button
+                onClick={() => exec('bold')}
+                title="Negrito"
+                className={`p-1 rounded ${formats.bold ? 'bg-gray-200' : ''}`}
+              >
+                <Bold className="h-4 w-4" />
+              </button>
+              <button
+                onClick={() => exec('italic')}
+                title="Itálico"
+                className={`p-1 rounded ${formats.italic ? 'bg-gray-200' : ''}`}
+              >
+                <Italic className="h-4 w-4" />
+              </button>
+              <button
+                onClick={() => exec('underline')}
+                title="Sublinhado"
+                className={`p-1 rounded ${formats.underline ? 'bg-gray-200' : ''}`}
+              >
+                <Underline className="h-4 w-4" />
+              </button>
+              <button
+                onClick={() => exec('strikeThrough')}
+                title="Tachado"
+                className={`p-1 rounded ${formats.strike ? 'bg-gray-200' : ''}`}
+              >
+                <Strikethrough className="h-4 w-4" />
+              </button>
+              <button
+                onClick={() => exec('insertUnorderedList')}
+                title="Lista"
+                className={`p-1 rounded ${formats.unordered ? 'bg-gray-200' : ''}`}
+              >
+                <List className="h-4 w-4" />
+              </button>
+              <button
+                onClick={() => exec('insertOrderedList')}
+                title="Lista numerada"
+                className={`p-1 rounded ${formats.ordered ? 'bg-gray-200' : ''}`}
+              >
+                <ListOrdered className="h-4 w-4" />
+              </button>
+              <button
+                onClick={() => exec('formatBlock', formats.h1 ? 'p' : 'h1')}
+                title="H1"
+                className={`p-1 rounded ${formats.h1 ? 'bg-gray-200' : ''}`}
+              >
+                <Heading1 className="h-4 w-4" />
+              </button>
+              <button
+                onClick={() => exec('formatBlock', formats.h2 ? 'p' : 'h2')}
+                title="H2"
+                className={`p-1 rounded ${formats.h2 ? 'bg-gray-200' : ''}`}
+              >
+                <Heading2 className="h-4 w-4" />
+              </button>
+              <button
+                onClick={() => exec('formatBlock', formats.h3 ? 'p' : 'h3')}
+                title="H3"
+                className={`p-1 rounded ${formats.h3 ? 'bg-gray-200' : ''}`}
+              >
+                <Heading3 className="h-4 w-4" />
+              </button>
+            </div>
+            <div
+              id="script-editor"
+              ref={editorRef}
+              className="min-h-[200px] border p-2 rounded"
+              contentEditable
+            />
+            <style jsx global>{`
+              #script-editor h1 { font-size: 1.5rem; font-weight: bold; }
+              #script-editor h2 { font-size: 1.25rem; font-weight: bold; }
+              #script-editor h3 { font-size: 1.125rem; font-weight: bold; }
+              #script-editor ul { list-style: disc; padding-left: 1.5rem; }
+              #script-editor ol { list-style: decimal; padding-left: 1.5rem; }
+            `}</style>
+          </CardContent>
+        </Card>
+        <div className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Softskills</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-wrap gap-2 mb-2">
+                {softskills.map((s, idx) => (
+                  <span
+                    key={idx}
+                    className="bg-purple-100 text-purple-800 px-2 py-1 rounded-full text-sm flex items-center gap-1"
+                  >
+                    {s}
+                    <button onClick={() => removeItem(idx, 'soft')}>
+                      <X className="h-3 w-3" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+              <button
+                className="mt-2 px-3 py-1 border rounded flex items-center gap-1"
+                onClick={() => setShowSidebar('soft')}
+              >
+                <Plus className="h-4 w-4" /> Adicionar critério
+              </button>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Fit cultural</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="flex flex-wrap gap-2 mb-2">
+                {fits.map((s, idx) => (
+                  <span
+                    key={idx}
+                    className="bg-purple-100 text-purple-800 px-2 py-1 rounded-full text-sm flex items-center gap-1"
+                  >
+                    {s}
+                    <button onClick={() => removeItem(idx, 'fit')}>
+                      <X className="h-3 w-3" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+              <button
+                className="mt-2 px-3 py-1 border rounded flex items-center gap-1"
+                onClick={() => setShowSidebar('fit')}
+              >
+                <Plus className="h-4 w-4" /> Adicionar critério
+              </button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+      {showSidebar && (
+        <div className="fixed inset-0 bg-black/50 flex justify-end z-50">
+          <aside className="bg-white w-80 h-full p-4 overflow-y-auto shadow-xl">
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-lg font-bold">Novo critério</h2>
+              <button
+                onClick={() => setShowSidebar(null)}
+                className="p-1 rounded hover:bg-gray-100"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <Input
+              placeholder="Nome"
+              value={criterion}
+              onChange={(e) => setCriterion(e.target.value)}
+              className="mb-2"
+            />
+            <button
+              onClick={addCriterion}
+              className="px-4 py-2 bg-blue-600 text-white rounded w-full"
+            >
+              Salvar
+            </button>
+          </aside>
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/components/recruitment/TalentModal.tsx
+++ b/components/recruitment/TalentModal.tsx
@@ -1,12 +1,20 @@
 import { useEffect, useState } from 'react';
 import { supabase } from '../../lib/supabaseClient';
 import { Button } from '../ui/button';
-import { X, Settings } from 'lucide-react';
+import { X, Settings, ChevronDown } from 'lucide-react';
 import TagSidebar from '../TagSidebar';
 
 interface Tag {
   name: string;
   color: string;
+}
+
+interface CustomField {
+  id: string;
+  label: string;
+  type: string;
+  options?: string[];
+  enabled?: boolean;
 }
 
 interface Props {
@@ -27,19 +35,66 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
   const [seniority, setSeniority] = useState('');
   const [availability, setAvailability] = useState('');
   const [source, setSource] = useState('');
+  const [status, setStatus] = useState('active');
   const [comment, setComment] = useState('');
   const [tags, setTags] = useState<Tag[]>([]);
   const [newTag, setNewTag] = useState('');
   const [newColor, setNewColor] = useState('#a855f7');
   const [suggestions, setSuggestions] = useState<Tag[]>([]);
   const [tagOpen, setTagOpen] = useState(false);
+  const [custom, setCustom] = useState<Record<string, any>>({});
+  const [orderedFields, setOrderedFields] = useState<
+    { id: string; type: 'builtin' | 'custom' }[]
+  >([]);
+  const [customMap, setCustomMap] = useState<Record<string, CustomField>>({});
+  const [wide, setWide] = useState<Set<string>>(new Set());
+
+  const fieldMeta: Record<
+    string,
+    { label: string; type: string; options?: { value: string; label: string }[] }
+  > = {
+    name: { label: 'Nome', type: 'text' },
+    email: { label: 'Email', type: 'email' },
+    phone: { label: 'Telefone', type: 'text' },
+    city: { label: 'Cidade', type: 'text' },
+    state: { label: 'Estado', type: 'text' },
+    cv_url: { label: 'Currículo URL', type: 'text' },
+    salary_expectation: { label: 'Pretensão salarial', type: 'number' },
+    seniority: { label: 'Senioridade', type: 'text' },
+    availability: { label: 'Disponibilidade', type: 'text' },
+    source: {
+      label: 'Origem',
+      type: 'select',
+      options: [
+        { value: 'career_site', label: 'Site' },
+        { value: 'referral', label: 'Indicação' },
+        { value: 'linkedin', label: 'LinkedIn' },
+        { value: 'import', label: 'Importação' },
+        { value: 'event', label: 'Evento' },
+        { value: 'other', label: 'Outro' },
+      ],
+    },
+  };
+
+  const builtinValues: Record<string, [string, (v: string) => void]> = {
+    name: [name, setName],
+    email: [email, setEmail],
+    phone: [phone, setPhone],
+    city: [city, setCity],
+    state: [state, setState],
+    cv_url: [cvUrl, setCvUrl],
+    salary_expectation: [salary, setSalary],
+    seniority: [seniority, setSeniority],
+    availability: [availability, setAvailability],
+    source: [source, setSource],
+  };
 
   useEffect(() => {
     const load = async () => {
       const { data: talent } = await supabase
         .from('talents')
         .select(
-          'name,email,phone,city,state,cv_url,salary_expectation,seniority,availability,source,comment,talent_tag_map(tag:talent_tags(name,color))'
+          'name,email,phone,city,state,cv_url,salary_expectation,seniority,availability,source,status,comment,talent_tag_map(tag:talent_tags(name,color))'
         )
         .eq('id', talentId)
         .single();
@@ -54,6 +109,7 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
         setSeniority(talent.seniority || '');
         setAvailability(talent.availability || '');
         setSource(talent.source || '');
+        setStatus(talent.status || 'active');
         setComment(talent.comment || '');
         setTags(
           talent.talent_tag_map?.map((m: any) => ({
@@ -65,6 +121,50 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
     };
     if (talentId) load();
   }, [talentId]);
+
+  useEffect(() => {
+    const load = async () => {
+      const { data: app } = await supabase
+        .from('applications')
+        .select('job_id, custom_answers')
+        .eq('id', applicationId)
+        .maybeSingle();
+      if (!app) return;
+      setCustom(app.custom_answers || {});
+      const { data: job } = await supabase
+        .from('jobs')
+        .select(
+          'form_fields, custom_fields, form_field_order, form_field_wide'
+        )
+        .eq('id', app.job_id)
+        .maybeSingle();
+      if (!job) return;
+      // include all built-in fields regardless of visibility on the public form
+      const builtins = new Set<string>(Object.keys(fieldMeta));
+      const cMap: Record<string, CustomField> = {};
+      // show custom fields even if they are disabled on the public form
+      (job.custom_fields || []).forEach((f: CustomField) => {
+        cMap[f.id] = f;
+      });
+      const fieldMap = new Map<string, { type: 'builtin' | 'custom' }>();
+      builtins.forEach((id) => fieldMap.set(id, { type: 'builtin' }));
+      Object.keys(cMap).forEach((id) => fieldMap.set(id, { type: 'custom' }));
+      const order: string[] = job.form_field_order || [];
+      const ordered: { id: string; type: 'builtin' | 'custom' }[] = [];
+      order.forEach((id) => {
+        const entry = fieldMap.get(id);
+        if (entry) {
+          ordered.push({ id, type: entry.type });
+          fieldMap.delete(id);
+        }
+      });
+      fieldMap.forEach((val, id) => ordered.push({ id, type: val.type }));
+      setOrderedFields(ordered);
+      setCustomMap(cMap);
+      setWide(new Set(job.form_field_wide || []));
+    };
+    if (applicationId) load();
+  }, [applicationId]);
 
   const refreshTags = async () => {
     const { data } = await supabase
@@ -111,20 +211,30 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
       .update({
         name,
         email,
-        phone,
-        city,
-        state,
-        cv_url: cvUrl,
+        phone: phone || null,
+        city: city || null,
+        state: state || null,
+        cv_url: cvUrl || null,
         salary_expectation: salary ? Number(salary) : null,
-        seniority,
-        availability,
-        source,
-        comment,
+        seniority: seniority || null,
+        availability: availability || null,
+        source: source || null,
+        status,
+        comment: comment || null,
       })
       .eq('id', talentId);
     if (tError) {
       console.error(tError);
       alert(tError.message);
+      return;
+    }
+    const { error: aError } = await supabase
+      .from('applications')
+      .update({ custom_answers: custom })
+      .eq('id', applicationId);
+    if (aError) {
+      console.error(aError);
+      alert(aError.message);
       return;
     }
     const { data: existing } = await supabase
@@ -171,99 +281,191 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
           </button>
         </div>
         <div className="grid gap-4 sm:grid-cols-2 mb-4">
+          {orderedFields.map((item) => {
+            if (item.type === 'builtin') {
+              const meta = fieldMeta[item.id];
+              if (!meta) return null;
+              const [val, setVal] = builtinValues[item.id] || ['', () => {}];
+              const full = wide.has(item.id);
+              return (
+                <div
+                  key={item.id}
+                  className={`flex flex-col ${full ? 'sm:col-span-2' : ''}`}
+                >
+                  <label className="block text-sm font-medium mb-1">
+                    {meta.label}
+                  </label>
+                  {meta.type === 'select' ? (
+                    <div className="relative">
+                      <select
+                        className="w-full border p-2 rounded appearance-none pr-8"
+                        value={val}
+                        onChange={(e) => setVal(e.target.value)}
+                      >
+                        <option value="">Selecione</option>
+                        {meta.options?.map((opt) => (
+                          <option key={opt.value} value={opt.value}>
+                            {opt.label}
+                          </option>
+                        ))}
+                      </select>
+                      <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500 pointer-events-none" />
+                    </div>
+                  ) : (
+                    <input
+                      type={meta.type}
+                      className="w-full border p-2 rounded"
+                      value={val}
+                      onChange={(e) => setVal(e.target.value)}
+                    />
+                  )}
+                </div>
+              );
+            }
+            const field = customMap[item.id];
+            if (!field) return null;
+            const value = custom[field.id];
+            const full =
+              wide.has(field.id) ||
+              field.type === 'textarea' ||
+              field.type === 'radio' ||
+              field.type === 'checkbox' ||
+              field.type === 'multiselect';
+            return (
+              <div
+                key={field.id}
+                className={`flex flex-col ${full ? 'sm:col-span-2' : ''}`}
+              >
+                <label className="block text-sm font-medium mb-1">
+                  {field.label}
+                </label>
+                {field.type === 'textarea' ? (
+                  <textarea
+                    className="w-full border p-2 rounded"
+                    value={value || ''}
+                    onChange={(e) =>
+                      setCustom({ ...custom, [field.id]: e.target.value })
+                    }
+                  />
+                ) : field.type === 'radio' ? (
+                  <div className="space-y-1">
+                    {field.options?.map((opt) => (
+                      <label key={opt} className="flex items-center gap-2">
+                        <input
+                          type="radio"
+                          name={field.id}
+                          value={opt}
+                          checked={value === opt}
+                          onChange={(e) =>
+                            setCustom({ ...custom, [field.id]: e.target.value })
+                          }
+                        />
+                        {opt}
+                      </label>
+                    ))}
+                  </div>
+                ) : field.type === 'checkbox' ? (
+                  <div className="space-y-1">
+                    {field.options?.map((opt) => (
+                      <label key={opt} className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          value={opt}
+                          checked={(value || []).includes(opt)}
+                          onChange={(e) => {
+                            const prev = value || [];
+                            const checked = e.target.checked;
+                            setCustom({
+                              ...custom,
+                              [field.id]: checked
+                                ? [...prev, opt]
+                                : prev.filter((x: string) => x !== opt),
+                            });
+                          }}
+                        />
+                        {opt}
+                      </label>
+                    ))}
+                  </div>
+                ) : field.type === 'select' ? (
+                  <select
+                    className="w-full border p-2 rounded"
+                    value={value || ''}
+                    onChange={(e) =>
+                      setCustom({ ...custom, [field.id]: e.target.value })
+                    }
+                  >
+                    <option value="">Selecione</option>
+                    {field.options?.map((opt) => (
+                      <option key={opt} value={opt}>
+                        {opt}
+                      </option>
+                    ))}
+                  </select>
+                ) : field.type === 'multiselect' ? (
+                  <select
+                    multiple
+                    className="w-full border p-2 rounded"
+                    value={value || []}
+                    onChange={(e) =>
+                      setCustom({
+                        ...custom,
+                        [field.id]: Array.from(
+                          e.target.selectedOptions,
+                          (o) => o.value
+                        ),
+                      })
+                    }
+                  >
+                    {field.options?.map((opt) => (
+                      <option key={opt} value={opt}>
+                        {opt}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    className="w-full border p-2 rounded"
+                    value={value || ''}
+                    onChange={(e) =>
+                      setCustom({ ...custom, [field.id]: e.target.value })
+                    }
+                  />
+                )}
+              </div>
+            );
+          })}
           <div className="sm:col-span-2">
-            <label className="block text-sm font-medium mb-1">Nome</label>
-            <input
-              className="w-full border p-2 rounded"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Email</label>
-            <input
-              className="w-full border p-2 rounded"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Telefone</label>
-            <input
-              className="w-full border p-2 rounded"
-              value={phone}
-              onChange={(e) => setPhone(e.target.value)}
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Cidade</label>
-            <input
-              className="w-full border p-2 rounded"
-              value={city}
-              onChange={(e) => setCity(e.target.value)}
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Estado</label>
-            <input
-              className="w-full border p-2 rounded"
-              value={state}
-              onChange={(e) => setState(e.target.value)}
-            />
-          </div>
-          <div className="sm:col-span-2">
-            <label className="block text-sm font-medium mb-1">URL do currículo</label>
-            <input
-              className="w-full border p-2 rounded"
-              value={cvUrl}
-              onChange={(e) => setCvUrl(e.target.value)}
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Pretensão salarial</label>
-            <input
-              type="number"
-              className="w-full border p-2 rounded"
-              value={salary}
-              onChange={(e) => setSalary(e.target.value)}
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Senioridade</label>
-            <input
-              className="w-full border p-2 rounded"
-              value={seniority}
-              onChange={(e) => setSeniority(e.target.value)}
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Disponibilidade</label>
-            <input
-              className="w-full border p-2 rounded"
-              value={availability}
-              onChange={(e) => setAvailability(e.target.value)}
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Fonte</label>
-            <select
-              className="w-full border p-2 rounded appearance-none pr-6"
-              value={source}
-              onChange={(e) => setSource(e.target.value)}
-            >
-              <option value="">Selecione</option>
-              <option value="career_site">Site</option>
-              <option value="referral">Indicação</option>
-              <option value="linkedin">LinkedIn</option>
-              <option value="import">Importação</option>
-              <option value="event">Evento</option>
-              <option value="other">Outro</option>
-            </select>
+            <label className="block text-sm font-medium mb-1">Status</label>
+            <div className="space-y-2">
+              {[
+                { value: 'active', label: 'Ativo' },
+                { value: 'withdrawn', label: 'Desistente' },
+                { value: 'rejected', label: 'Reprovado' },
+              ].map((opt) => (
+                <label key={opt.value} className="flex items-center gap-2 text-sm">
+                  <input
+                    type="radio"
+                    name="status"
+                    value={opt.value}
+                    checked={status === opt.value}
+                    onChange={(e) => setStatus(e.target.value)}
+                    className="h-4 w-4 accent-brand"
+                  />
+                  {opt.label}
+                </label>
+              ))}
+            </div>
           </div>
           <div className="sm:col-span-2">
             <div className="flex items-center justify-between mb-1">
               <div className="font-medium">Tags</div>
-              <Button type="button" variant="outline" size="icon" onClick={() => setTagOpen(true)}>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                onClick={() => setTagOpen(true)}
+              >
                 <Settings className="h-4 w-4" />
               </Button>
             </div>
@@ -284,9 +486,9 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
               ))}
             </div>
             <div className="flex flex-wrap items-center gap-2">
-              <div className="flex-1">
+              <div className="flex-1 relative">
                 <input
-                  className="w-full border p-2 rounded appearance-none"
+                  className="w-full border p-2 rounded appearance-none pr-8"
                   placeholder="Adicionar tag"
                   value={newTag}
                   list="tag-suggestions"
@@ -297,6 +499,7 @@ export default function TalentModal({ talentId, applicationId, companyId, onClos
                     setNewColor(found?.color || '#a855f7');
                   }}
                 />
+                <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500 pointer-events-none" />
               </div>
               <datalist id="tag-suggestions">
                 {suggestions.map((s) => (

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -14,3 +14,20 @@ export function Card({ className, ...props }: CardProps) {
     />
   );
 }
+
+export function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('mb-4', className)} {...props} />;
+}
+
+export function CardTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
+  return <h3 className={cn('text-lg font-semibold leading-6', className)} {...props} />;
+}
+
+export function CardContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('space-y-4', className)} {...props} />;
+}
+
+export function CardFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('mt-4', className)} {...props} />;
+}
+

--- a/docs/recruitment-selection.md
+++ b/docs/recruitment-selection.md
@@ -15,8 +15,16 @@ Principais objetivos:
 - **skills**, **talent_skill_map**: habilidades técnicas ou comportamentais.
 - **jobs**: vagas com status e etapas personalizadas.
 - **job_stages**: etapas padrão por empresa ou sobrescritas por vaga.
+- **job_metrics**: estatísticas agregadas por vaga (ex.: cliques no link).
+- **job_scripts**: roteiros de entrevista com texto, softskills e critérios de fit cultural por vaga.
+- **job_form_configs**: versões salvas da disposição do formulário público para cada vaga.
+- **jobs.custom_fields**: campos adicionais definidos pela empresa para o formulário público (cada item possui `id`, `label`, `type`, `options?` e `enabled` para ativar ou ocultar o campo).
+- **jobs.form_field_order**: sequência de IDs (padrão e personalizados) que define a ordem dos campos exibidos no formulário público.
+- **jobs.form_field_wide**: lista de IDs dos campos que devem ocupar toda a largura do formulário público.
 - **applications**: vínculo talento↔vaga com estágio atual.
+- **applications.custom_answers**: respostas dos candidatos aos campos personalizados.
 - **application_stage_history**: histórico de mudanças de etapa e SLAs.
+- **application_stage_dates**: registro das datas de entrada e saída em cada etapa.
 - **application_events**: auditoria de ações (quem, quando, payload).
 - **reports_cache**: materialização periódica de métricas.
 
@@ -26,7 +34,10 @@ Principais objetivos:
 - `applications.job_id -> jobs.id`
 - `applications.talent_id -> talents.id`
 - `job_stages.job_id -> jobs.id` (ou nulo para padrão da empresa)
+- `job_metrics.job_id -> jobs.id`
+- `job_scripts.job_id -> jobs.id`
 - `application_stage_history.application_id -> applications.id`
+- `application_stage_dates.application_id -> applications.id`
 - `application_events.application_id -> applications.id`
 
 ## 3. Script SQL (Supabase)
@@ -37,6 +48,7 @@ create type job_status as enum ('open','closed','frozen');
 create type application_stage as enum ('applied','screening','interview','offer','admitted','rejected','withdrawn');
 create type candidate_source as enum ('career_site','referral','linkedin','import','event','other');
 create type rejection_reason as enum ('lack_of_skill','cultural_fit','salary','position_filled','candidate_withdrew','other');
+create type talent_status as enum ('active','withdrawn','rejected');
 
 -- Talents
 create table talents (
@@ -54,6 +66,7 @@ create table talents (
   seniority text,
   availability text,
   source candidate_source,
+  status talent_status default 'active',
   consent_at timestamptz,
   created_at timestamptz default now(),
   updated_at timestamptz default now(),

--- a/explanation.txt
+++ b/explanation.txt
@@ -1,0 +1,10 @@
+This project counts link clicks using Supabase.
+
+1. **Database schema**
+   - The `job_metrics` table stores a row per job with a `link_clicks` column. A SQL function `increment_job_link_click` inserts or updates this row, adding one to `link_clicks` on each call.
+2. **When a candidate visits the job page**
+   - The public job application page (`pages/apply/[id].tsx`) calls `increment_job_link_click` on every request to record the visit.
+3. **Displaying the total**
+   - The metrics tab fetches the `link_clicks` value from `job_metrics` and shows it as the first bar of the funnel chart (`components/recruitment/JobMetrics.tsx`).
+
+This flow ensures that every time someone clicks the job link, the backend counter increments and the metrics dashboard reflects the updated total.

--- a/pages/api/apply.ts
+++ b/pages/api/apply.ts
@@ -8,7 +8,11 @@ const supabase = createClient(supabaseUrl, serviceRoleKey);
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).end();
 
-  const { job_id, data } = req.body as { job_id: string; data: Record<string, any> };
+  const { job_id, data, custom } = req.body as {
+    job_id: string;
+    data: Record<string, any>;
+    custom?: Record<string, any>;
+  };
 
   const { data: job, error: jobError } = await supabase
     .from('jobs')
@@ -107,24 +111,48 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(400).json({ error: existingErr.message });
   }
 
+  let appId = existingApp?.id;
   let appError;
   if (existingApp) {
     ({ error: appError } = await supabase
       .from('applications')
-      .update({ stage_id: firstStage?.id || null })
+      .update({ stage_id: firstStage?.id || null, custom_answers: custom || {} })
       .eq('id', existingApp.id));
   } else {
-    ({ error: appError } = await supabase.from('applications').insert({
-      company_id: job.company_id,
-      job_id,
-      talent_id: talent.id,
-      stage_id: firstStage?.id || null,
-    }));
+    const { data: inserted, error } = await supabase
+      .from('applications')
+      .insert({
+        company_id: job.company_id,
+        job_id,
+        talent_id: talent.id,
+        stage_id: firstStage?.id || null,
+        custom_answers: custom || {},
+      })
+      .select('id')
+      .single();
+    appError = error;
+    appId = inserted?.id;
   }
 
-  if (appError) {
+  if (appError || !appId) {
     console.error('Application save error', appError);
-    return res.status(400).json({ error: appError.message });
+    return res.status(400).json({ error: appError?.message || 'Erro ao salvar candidatura' });
+  }
+
+  if (firstStage?.id) {
+    const today = new Date().toISOString().split('T')[0];
+    const { data: existingStage } = await supabase
+      .from('application_stage_dates')
+      .select('day_in')
+      .eq('application_id', appId)
+      .eq('stage_id', firstStage.id)
+      .maybeSingle();
+    await supabase.from('application_stage_dates').upsert({
+      application_id: appId,
+      stage_id: firstStage.id,
+      day_in: existingStage?.day_in || today,
+      day_out: null,
+    });
   }
 
   return res.status(200).json({ success: true });

--- a/pages/apply/[id].tsx
+++ b/pages/apply/[id].tsx
@@ -3,7 +3,23 @@ import { useState } from 'react';
 import { createClient } from '@supabase/supabase-js';
 
 interface JobProps {
-  job: { id: string; title: string; company_id: string; form_fields: string[] };
+  job: {
+    id: string;
+    title: string;
+    company_id: string;
+    form_fields: string[];
+    custom_fields: CustomField[];
+    form_field_order: string[];
+    form_field_wide: string[];
+  };
+}
+
+interface CustomField {
+  id: string;
+  label: string;
+  type: string;
+  options?: string[];
+  enabled?: boolean;
 }
 
 const fieldMeta: Record<string, { label: string; type: string; options?: { value: string; label: string }[] }> = {
@@ -32,6 +48,7 @@ const fieldMeta: Record<string, { label: string; type: string; options?: { value
 
 export default function Apply({ job }: JobProps) {
   const [form, setForm] = useState<Record<string, string>>({});
+  const [custom, setCustom] = useState<Record<string, any>>({});
   const [done, setDone] = useState(false);
 
   const submit = async (e: React.FormEvent) => {
@@ -39,7 +56,7 @@ export default function Apply({ job }: JobProps) {
     const res = await fetch('/api/apply', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ job_id: job.id, data: form }),
+      body: JSON.stringify({ job_id: job.id, data: form, custom }),
     });
     if (res.ok) setDone(true);
   };
@@ -49,38 +66,172 @@ export default function Apply({ job }: JobProps) {
   return (
     <div className="p-4 max-w-xl mx-auto">
       <h1 className="text-2xl font-bold mb-4">{job.title}</h1>
-      <form onSubmit={submit} className="space-y-4">
-        {job.form_fields.map((field) => {
-          const meta = fieldMeta[field];
-          if (!meta) return null;
-          return (
-            <div key={field} className="flex flex-col">
-              <label className="mb-1 font-medium">{meta.label}</label>
-              {meta.type === 'select' ? (
-                <select
-                  required
-                  className="border p-2 rounded"
-                  onChange={(e) => setForm({ ...form, [field]: e.target.value })}
-                >
-                  <option value="">Selecione</option>
-                  {meta.options?.map((opt) => (
-                    <option key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </option>
-                  ))}
-                </select>
-              ) : (
-                <input
-                  type={meta.type}
-                  required
-                  className="border p-2 rounded"
-                  onChange={(e) => setForm({ ...form, [field]: e.target.value })}
-                />
-              )}
-            </div>
+      <form onSubmit={submit} className="grid grid-cols-2 gap-4">
+        {(() => {
+          const order = job.form_field_order || [];
+          const builtins = new Set(job.form_fields);
+          const customMap: Record<string, CustomField> = {};
+          job.custom_fields
+            .filter((f) => f.enabled !== false)
+            .forEach((f) => (customMap[f.id] = f));
+          const wide = new Set(job.form_field_wide || []);
+          const fieldMap = new Map<string, { type: 'builtin' | 'custom' }>();
+          builtins.forEach((id) => fieldMap.set(id, { type: 'builtin' }));
+          Object.keys(customMap).forEach((id) =>
+            fieldMap.set(id, { type: 'custom' })
           );
-        })}
-        <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+          const ordered: { id: string; type: 'builtin' | 'custom' }[] = [];
+          order.forEach((id) => {
+            const entry = fieldMap.get(id);
+            if (entry) {
+              ordered.push({ id, type: entry.type });
+              fieldMap.delete(id);
+            }
+          });
+          fieldMap.forEach((val, id) => ordered.push({ id, type: val.type }));
+          return ordered.map((item) => {
+            if (item.type === 'builtin') {
+              const meta = fieldMeta[item.id];
+              if (!meta) return null;
+              const full = wide.has(item.id);
+              return (
+                <div key={item.id} className={`flex flex-col ${full ? 'col-span-2' : ''}`}>
+                  <label className="mb-1 font-medium">{meta.label}</label>
+                  {meta.type === 'select' ? (
+                    <select
+                      required
+                      className="border p-2 rounded"
+                      onChange={(e) =>
+                        setForm({ ...form, [item.id]: e.target.value })
+                      }
+                    >
+                      <option value="">Selecione</option>
+                      {meta.options?.map((opt) => (
+                        <option key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <input
+                      type={meta.type}
+                      required
+                      className="border p-2 rounded"
+                      onChange={(e) =>
+                        setForm({ ...form, [item.id]: e.target.value })
+                      }
+                    />
+                  )}
+                </div>
+              );
+            }
+            const field = customMap[item.id];
+            if (!field) return null;
+            const full =
+              wide.has(field.id) ||
+              field.type === 'textarea' ||
+              field.type === 'radio' ||
+              field.type === 'checkbox' ||
+              field.type === 'multiselect';
+            return (
+              <div
+                key={field.id}
+                className={`flex flex-col ${full ? 'col-span-2' : ''}`}
+              >
+                <label className="mb-1 font-medium">{field.label}</label>
+                {field.type === 'textarea' ? (
+                  <textarea
+                    className="border p-2 rounded"
+                    onChange={(e) =>
+                      setCustom({ ...custom, [field.id]: e.target.value })
+                    }
+                  />
+                ) : field.type === 'radio' ? (
+                  <div className="space-y-1">
+                    {field.options?.map((opt) => (
+                      <label key={opt} className="flex items-center gap-2">
+                        <input
+                          type="radio"
+                          name={field.id}
+                          value={opt}
+                          onChange={(e) =>
+                            setCustom({ ...custom, [field.id]: e.target.value })
+                          }
+                        />
+                        {opt}
+                      </label>
+                    ))}
+                  </div>
+                ) : field.type === 'checkbox' ? (
+                  <div className="space-y-1">
+                    {field.options?.map((opt) => (
+                      <label key={opt} className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          value={opt}
+                          onChange={(e) => {
+                            const prev = custom[field.id] || [];
+                            const checked = e.target.checked;
+                            setCustom({
+                              ...custom,
+                              [field.id]: checked
+                                ? [...prev, opt]
+                                : prev.filter((x: string) => x !== opt),
+                            });
+                          }}
+                        />
+                        {opt}
+                      </label>
+                    ))}
+                  </div>
+                ) : field.type === 'select' ? (
+                  <select
+                    className="border p-2 rounded"
+                    onChange={(e) =>
+                      setCustom({ ...custom, [field.id]: e.target.value })
+                    }
+                  >
+                    <option value="">Selecione</option>
+                    {field.options?.map((opt) => (
+                      <option key={opt} value={opt}>
+                        {opt}
+                      </option>
+                    ))}
+                  </select>
+                ) : field.type === 'multiselect' ? (
+                  <select
+                    multiple
+                    className="border p-2 rounded"
+                    onChange={(e) => {
+                      const selected = Array.from(
+                        e.target.selectedOptions
+                      ).map((o) => o.value);
+                      setCustom({ ...custom, [field.id]: selected });
+                    }}
+                  >
+                    {field.options?.map((opt) => (
+                      <option key={opt} value={opt}>
+                        {opt}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    type="text"
+                    className="border p-2 rounded"
+                    onChange={(e) =>
+                      setCustom({ ...custom, [field.id]: e.target.value })
+                    }
+                  />
+                )}
+              </div>
+            );
+          });
+        })()}
+        <button
+          type="submit"
+          className="col-span-2 px-4 py-2 bg-blue-600 text-white rounded"
+        >
           Enviar
         </button>
       </form>
@@ -95,11 +246,12 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   );
   const { data: job } = await supabase
     .from('jobs')
-    .select('id,title,company_id,form_fields')
+    .select('id,title,company_id,form_fields,custom_fields,form_field_order,form_field_wide')
     .eq('id', params?.id)
     .maybeSingle();
   if (!job) {
     return { notFound: true };
   }
+  await supabase.rpc('increment_job_link_click', { j: job.id });
   return { props: { job } };
 };

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -50,8 +50,8 @@ export default function Dashboard() {
         .from('companies')
         .select('maxemployees')
         .eq('id', companyId)
-        .single();
-      if (company?.maxemployees === 0) {
+        .maybeSingle();
+      if (company && company.maxemployees === 0) {
         router.replace(`/pending?companyId=${companyId}`);
         return;
       }

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -65,8 +65,8 @@ export default function Login() {
       .from('companies')
       .select('maxemployees')
       .eq('id', companyId)
-      .single();
-    if (company?.maxemployees === 0) {
+      .maybeSingle();
+    if (company && company.maxemployees === 0) {
       router.push(`/pending?companyId=${companyId}`);
     } else {
       router.push('/dashboard');

--- a/pages/recruitment/jobs/[id].tsx
+++ b/pages/recruitment/jobs/[id].tsx
@@ -5,11 +5,13 @@ import { useEffect, useState } from 'react';
 import Layout from '../../../components/Layout';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../../../components/ui/tabs';
 import JobTalentBoard from '../../../components/recruitment/JobTalentBoard';
+import JobMetrics from '../../../components/recruitment/JobMetrics';
+import RoteiroTab from '../../../components/recruitment/RoteiroTab';
 import { supabase } from '../../../lib/supabaseClient';
 import { Input } from '../../../components/ui/input';
 import { Button } from '../../../components/ui/button';
 import { getSourceLabel } from '../../../lib/utils';
-import { Plus, X } from 'lucide-react';
+import { Plus, X, GripVertical } from 'lucide-react';
 
 interface Job {
   id: string;
@@ -31,13 +33,37 @@ interface Job {
   workload: string | null;
   seniority: string | null;
   form_fields: string[] | null;
+  custom_fields: CustomField[] | null;
+  form_field_order: string[] | null;
+  form_field_wide: string[] | null;
+}
+
+interface CustomField {
+  id: string;
+  label: string;
+  type: string;
+  options?: string[];
+  enabled?: boolean;
 }
 
 export default function JobDetails() {
   const router = useRouter();
   const { id } = router.query;
   const [job, setJob] = useState<Job | null>(null);
-  const [fields, setFields] = useState<string[]>([]);
+  interface FormFieldItem {
+    id: string;
+    label: string;
+    type?: string;
+    options?: string[];
+    enabled: boolean;
+    isCustom: boolean;
+    span: number;
+  }
+  const [fieldList, setFieldList] = useState<FormFieldItem[]>([]);
+  const [showFieldModal, setShowFieldModal] = useState(false);
+  const [cfType, setCfType] = useState('text');
+  const [cfLabel, setCfLabel] = useState('');
+  const [cfOptions, setCfOptions] = useState<string[]>(['']);
   const [managers, setManagers] = useState<{ user_id: string; name: string }[]>([]);
   const [candidateCount, setCandidateCount] = useState(0);
   const [sourceDist, setSourceDist] = useState<Record<string, number>>({});
@@ -53,13 +79,115 @@ export default function JobDetails() {
   ]);
   const [newContract, setNewContract] = useState('');
   const [showMsg, setShowMsg] = useState(false);
+  const [fieldsMsg, setFieldsMsg] = useState(false);
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+
+  interface FormConfig {
+    id: string;
+    name: string;
+    config: FormFieldItem[];
+  }
+  const [forms, setForms] = useState<FormConfig[]>([]);
+  const [formName, setFormName] = useState('');
+  const [currentFormId, setCurrentFormId] = useState<string | null>(null);
+
+  const Toggle = ({
+    on,
+    onChange,
+  }: {
+    on: boolean;
+    onChange: (v: boolean) => void;
+  }) => (
+    <button
+      type="button"
+      onClick={() => onChange(!on)}
+      className={`w-10 h-5 flex items-center rounded-full p-1 transition-colors ${on ? 'bg-purple-600' : 'bg-gray-300'}`}
+    >
+      <span
+        className={`bg-white w-4 h-4 rounded-full transform transition ${on ? 'translate-x-5' : 'translate-x-0'}`}
+      />
+    </button>
+  );
+
+  useEffect(() => {
+    loadForms();
+  }, [id]);
+
+  async function loadForms() {
+    if (!id || Array.isArray(id)) return;
+    const { data } = await supabase
+      .from('job_form_configs')
+      .select('id,name,config')
+      .eq('job_id', id);
+    if (data) {
+      setForms(data as any);
+      if (data.length && !currentFormId) {
+        const f = data[0] as any;
+        setCurrentFormId(f.id);
+        setFormName(f.name);
+        const cfg = f.config as FormFieldItem[];
+        setFieldList(cfg);
+        applyConfig(cfg);
+      }
+    }
+  }
+
+  function selectForm(fid: string) {
+    const f = forms.find((fc) => fc.id === fid);
+    if (!f) return;
+    setCurrentFormId(f.id);
+    setFormName(f.name);
+    const cfg = f.config as FormFieldItem[];
+    setFieldList(cfg);
+    applyConfig(cfg);
+  }
+
+  async function applyConfig(cfg: FormFieldItem[]) {
+    if (!id || Array.isArray(id)) return;
+    const builtins = cfg
+      .filter((f) => !f.isCustom && f.enabled)
+      .map((f) => f.id);
+    const custom = cfg
+      .filter((f) => f.isCustom)
+      .map(({ id, label, type, options, enabled }) => ({
+        id,
+        label,
+        type: type!,
+        options,
+        enabled,
+      }));
+    const order = cfg.map((f) => f.id);
+    const wide = cfg.filter((f) => f.span === 2).map((f) => f.id);
+    const { error } = await supabase
+      .from('jobs')
+      .update({
+        form_fields: builtins,
+        custom_fields: custom,
+        form_field_order: order,
+        form_field_wide: wide,
+      })
+      .eq('id', id);
+    if (!error) {
+      setJob((prev) =>
+        prev
+          ? {
+              ...prev,
+              form_fields: builtins,
+              custom_fields: custom as any,
+              form_field_order: order,
+              form_field_wide: wide,
+            }
+          : prev
+      );
+    }
+  }
 
   useEffect(() => {
     if (!id || Array.isArray(id)) return;
     supabase
       .from('jobs')
       .select(
-        'id,company_id,title,department,manager_id,status,opened_at,sla,work_location,summary,responsibilities,requirements,desirables,salary_range,benefits,contract_type,workload,seniority,form_fields'
+        'id,company_id,title,department,manager_id,status,opened_at,sla,work_location,summary,responsibilities,requirements,desirables,salary_range,benefits,contract_type,workload,seniority,form_fields,custom_fields,form_field_order,form_field_wide'
       )
       .eq('id', id)
       .maybeSingle()
@@ -86,7 +214,45 @@ export default function JobDetails() {
             jobData.workload = m ? m[0] : jobData.workload;
           }
           setJob(jobData);
-          setFields((data.form_fields as string[]) || ['name', 'email']);
+          const builtins = (data.form_fields as string[]) || ['name', 'email'];
+          const customDefs = ((data.custom_fields as CustomField[]) || []).map(
+            (f) => ({ ...f, enabled: f.enabled ?? true })
+          );
+          const order = (data.form_field_order as string[]) || [];
+          const wideSet = new Set((data.form_field_wide as string[]) || []);
+          const builtinItems = talentFields.map((tf) => ({
+            id: tf.id,
+            label: tf.label,
+            isCustom: false,
+            enabled: builtins.includes(tf.id),
+            span: wideSet.has(tf.id) ? 2 : 1,
+          }));
+          const customItems = customDefs.map((cf) => ({
+            id: cf.id,
+            label: cf.label,
+            type: cf.type,
+            options: cf.options,
+            enabled: cf.enabled !== false,
+            isCustom: true,
+            span:
+              wideSet.has(cf.id) ||
+              ['textarea', 'radio', 'checkbox', 'multiselect'].includes(cf.type)
+                ? 2
+                : 1,
+          }));
+          const map = new Map(
+            [...builtinItems, ...customItems].map((f) => [f.id, f])
+          );
+          const ordered: FormFieldItem[] = [];
+          order.forEach((id: string) => {
+            const item = map.get(id);
+            if (item) {
+              ordered.push(item);
+              map.delete(id);
+            }
+          });
+          map.forEach((item) => ordered.push(item));
+          setFieldList(ordered);
           const { data: mgrs } = await supabase
             .from('companies_users')
             .select('user_id,name')
@@ -121,17 +287,70 @@ export default function JobDetails() {
     { id: 'availability', label: 'Disponibilidade' },
   ];
 
-  const saveFields = async () => {
+  const saveFormConfig = async () => {
     if (!id || Array.isArray(id)) return;
+    const builtins = fieldList
+      .filter((f) => !f.isCustom && f.enabled)
+      .map((f) => f.id);
+    const custom = fieldList
+      .filter((f) => f.isCustom)
+      .map(({ id, label, type, options, enabled }) => ({
+        id,
+        label,
+        type: type!,
+        options,
+        enabled,
+      }));
+    const order = fieldList.map((f) => f.id);
+    const wide = fieldList.filter((f) => f.span === 2).map((f) => f.id);
+
+    const { data: saved, error: cfgErr } = await supabase
+      .from('job_form_configs')
+      .upsert({
+        id: currentFormId || undefined,
+        job_id: id,
+        name: formName,
+        config: fieldList,
+      })
+      .select()
+      .single();
+    if (cfgErr) {
+      console.error(cfgErr);
+      alert(cfgErr.message);
+      return;
+    }
+    setCurrentFormId(saved.id);
+
     const { error } = await supabase
       .from('jobs')
-      .update({ form_fields: fields })
+      .update({
+        form_fields: builtins,
+        custom_fields: custom,
+        form_field_order: order,
+        form_field_wide: wide,
+      })
       .eq('id', id);
     if (error) {
       console.error(error);
       alert(error.message);
+    } else {
+      loadForms();
+      setFieldsMsg(true);
+      setTimeout(() => setFieldsMsg(false), 3000);
     }
   };
+
+  const handleDragStartField = (index: number) => setDragIndex(index);
+  const handleDragOverField = (index: number, e: React.DragEvent) => {
+    e.preventDefault();
+    if (dragIndex === null || dragIndex === index) return;
+    const updated = [...fieldList];
+    const [moved] = updated.splice(dragIndex, 1);
+    updated.splice(index, 0, moved);
+    setFieldList(updated);
+    setDragIndex(index);
+  };
+  const handleDragEndField = () => setDragIndex(null);
 
   const publicLink =
     typeof window !== 'undefined' && id
@@ -573,33 +792,119 @@ export default function JobDetails() {
             )}
           </TabsContent>
           <TabsContent value="metrics">
-            <p>Métricas em construção.</p>
+            {id && !Array.isArray(id) && <JobMetrics jobId={id} />}
           </TabsContent>
           <TabsContent value="ads">
             <div className="space-y-4">
+              <div className="flex gap-2 items-center">
+                <Input
+                  value={formName}
+                  onChange={(e) => setFormName(e.target.value)}
+                  placeholder="Nome do formulário"
+                  className="flex-1"
+                />
+                <select
+                  className="border p-2 rounded"
+                  value={currentFormId || ''}
+                  onChange={(e) => selectForm(e.target.value)}
+                >
+                  <option value="">Carregar formulário...</option>
+                  {forms.map((f) => (
+                    <option key={f.id} value={f.id}>
+                      {f.name}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  onClick={saveFormConfig}
+                  className="px-4 py-2 bg-blue-600 text-white rounded"
+                >
+                  Salvar formulário
+                </button>
+              </div>
+              {fieldsMsg && (
+                <div className="fixed top-4 right-4 bg-green-100 border border-green-400 text-green-800 px-4 py-2 rounded">
+                  alterações salvas com sucesso!!
+                </div>
+              )}
               <div>
                 <p className="font-medium mb-2">Campos do formulário público</p>
-                {talentFields.map((f) => (
-                  <label key={f.id} className="flex items-center gap-2 mb-1">
-                    <input
-                      type="checkbox"
-                      checked={fields.includes(f.id)}
-                      onChange={(e) => {
-                        setFields(
-                          e.target.checked
-                            ? [...fields, f.id]
-                            : fields.filter((x) => x !== f.id)
-                        );
-                      }}
-                    />
-                    {f.label}
-                  </label>
-                ))}
+                <div className="grid grid-cols-2 gap-2">
+                  {fieldList.map((f, idx) => (
+                    <div
+                      key={f.id}
+                      className={`border rounded p-2 flex items-center gap-2 bg-white ${f.span === 2 ? 'col-span-2' : ''}`}
+                      draggable
+                      onDragStart={() => handleDragStartField(idx)}
+                      onDragOver={(e) => handleDragOverField(idx, e)}
+                      onDragEnd={handleDragEndField}
+                    >
+                      <GripVertical className="h-4 w-4 text-gray-400" />
+                      <span className="flex-1">
+                        {f.label}
+                        {f.isCustom && (
+                          <span className="text-sm text-gray-500"> ({f.type})</span>
+                        )}
+                      </span>
+                      <button
+                        type="button"
+                        className="text-gray-400 hover:text-gray-600"
+                        onClick={() =>
+                          setFieldList(
+                            fieldList.map((item, i) =>
+                              i === idx
+                                ? { ...item, span: item.span === 2 ? 1 : 2 }
+                                : item
+                            )
+                          )
+                        }
+                        title={f.span === 2 ? 'Metade da largura' : 'Largura completa'}
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          className="h-4 w-4"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M4 12h16M8 8h-4v8h4V8zm12 0h-4v8h4V8z"
+                          />
+                        </svg>
+                      </button>
+                      <Toggle
+                        on={f.enabled}
+                        onChange={(v) =>
+                          setFieldList(
+                            fieldList.map((item, i) =>
+                              i === idx ? { ...item, enabled: v } : item
+                            )
+                          )
+                        }
+                      />
+                      {f.isCustom && (
+                        <button
+                          className="text-gray-400 hover:text-red-600"
+                          onClick={() =>
+                            setFieldList(
+                              fieldList.filter((item) => item.id !== f.id)
+                            )
+                          }
+                        >
+                          <X className="h-4 w-4" />
+                        </button>
+                      )}
+                    </div>
+                  ))}
+                </div>
                 <button
-                  onClick={saveFields}
-                  className="mt-2 px-4 py-2 bg-blue-600 text-white rounded"
+                  onClick={() => setShowFieldModal(true)}
+                  className="mt-2 px-3 py-1 border rounded flex items-center gap-1"
                 >
-                  Salvar
+                  <Plus className="h-4 w-4" /> Adicionar campo
                 </button>
               </div>
               {publicLink && (
@@ -616,9 +921,129 @@ export default function JobDetails() {
             </div>
           </TabsContent>
           <TabsContent value="settings">
-            <p>Roteiro em construção.</p>
+            {id && !Array.isArray(id) && <RoteiroTab jobId={id} />}
           </TabsContent>
         </Tabs>
+        {showFieldModal && (
+          <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+            <div className="bg-white rounded p-4 w-full max-w-md max-h-[80vh] overflow-y-auto">
+              <div className="flex justify-between items-center mb-4">
+                <h2 className="text-lg font-bold">Novo campo</h2>
+                <button
+                  onClick={() => setShowFieldModal(false)}
+                  className="p-1 rounded hover:bg-gray-100"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+              <div className="mb-2">
+                <label className="block text-sm mb-1">Tipo</label>
+                <select
+                  className="w-full border p-2 rounded"
+                  value={cfType}
+                  onChange={(e) => setCfType(e.target.value)}
+                >
+                  <option value="text">Input</option>
+                  <option value="textarea">Textarea</option>
+                  <option value="radio">Radio</option>
+                  <option value="checkbox">Checkbox</option>
+                  <option value="select">Select</option>
+                  <option value="multiselect">Multi-select</option>
+                </select>
+              </div>
+              <div className="mb-2">
+                <label className="block text-sm mb-1">Nome</label>
+                <input
+                  className="w-full border p-2 rounded"
+                  value={cfLabel}
+                  onChange={(e) => setCfLabel(e.target.value)}
+                />
+              </div>
+              {(cfType === 'radio' ||
+                cfType === 'checkbox' ||
+                cfType === 'select' ||
+                cfType === 'multiselect') && (
+                <div className="mb-2">
+                  <label className="block text-sm mb-1">Opções</label>
+                  {cfOptions.map((opt, idx) => (
+                    <div key={idx} className="flex items-center gap-2 mb-1">
+                      <input
+                        className="border p-1 rounded flex-1"
+                        value={opt}
+                        onChange={(e) => {
+                          const newOpts = [...cfOptions];
+                          newOpts[idx] = e.target.value;
+                          setCfOptions(newOpts);
+                        }}
+                      />
+                      <button
+                        className="text-red-600 text-sm"
+                        onClick={() =>
+                          setCfOptions(cfOptions.filter((_, i) => i !== idx))
+                        }
+                      >
+                        <X className="h-4 w-4" />
+                      </button>
+                    </div>
+                  ))}
+                  <button
+                    className="text-blue-600 text-sm mt-1"
+                    onClick={() => setCfOptions([...cfOptions, ''])}
+                  >
+                    Adicionar opção
+                  </button>
+                </div>
+              )}
+              <div className="flex justify-end gap-2 mt-4">
+                <button
+                  onClick={() => setShowFieldModal(false)}
+                  className="px-4 py-2 border rounded"
+                >
+                  Cancelar
+                </button>
+                <button
+                  onClick={() => {
+                    const label = cfLabel.trim();
+                    if (!label) return;
+                    const field: CustomField = {
+                      id: crypto.randomUUID(),
+                      label,
+                      type: cfType,
+                      enabled: true,
+                      ...(cfType === 'radio' ||
+                      cfType === 'checkbox' ||
+                      cfType === 'select' ||
+                      cfType === 'multiselect'
+                        ? { options: cfOptions.filter((o) => o.trim()) }
+                        : {}),
+                    };
+                    setFieldList([
+                      ...fieldList,
+                      {
+                        ...field,
+                        isCustom: true,
+                        enabled: field.enabled ?? true,
+                        span:
+                          ['textarea', 'radio', 'checkbox', 'multiselect'].includes(
+                            cfType
+                          )
+                            ? 2
+                            : 1,
+                      },
+                    ]);
+                    setCfLabel('');
+                    setCfOptions(['']);
+                    setCfType('text');
+                    setShowFieldModal(false);
+                  }}
+                  className="px-4 py-2 bg-blue-600 text-white rounded"
+                >
+                  Salvar
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
       </Layout>
     </>
   );

--- a/supabaserecrutamento.sql
+++ b/supabaserecrutamento.sql
@@ -9,6 +9,7 @@ create type job_status as enum ('open','closed','frozen');
 create type application_status as enum ('applied','screening','interview','offer','admitted','rejected','withdrawn');
 create type candidate_source as enum ('career_site','referral','linkedin','import','event','other');
 create type rejection_reason as enum ('lack_of_skill','cultural_fit','salary','position_filled','candidate_withdrew','other');
+create type talent_status as enum ('active','withdrawn','rejected');
 
 -- Talents
 create table if not exists talents (
@@ -27,6 +28,7 @@ create table if not exists talents (
   seniority text,
   availability text,
   source candidate_source,
+  status talent_status default 'active',
   consent_at timestamptz,
   created_at timestamptz default now(),
   updated_at timestamptz default now(),
@@ -85,12 +87,24 @@ create table if not exists jobs (
   workload text,
   seniority text,
   form_fields jsonb default '["name","email"]',
+  custom_fields jsonb default '[]',
+  form_field_order jsonb default '[]',
+  form_field_wide jsonb default '[]',
   created_at timestamptz default now(),
   created_by uuid references auth.users(id),
   constraint jobs_manager_fkey foreign key (company_id, manager_id)
     references companies_users(company_id, user_id)
 );
 comment on table jobs is 'Vagas de recrutamento';
+
+alter table if exists jobs
+  add column if not exists custom_fields jsonb default '[]';
+
+alter table if exists jobs
+  add column if not exists form_field_order jsonb default '[]';
+
+alter table if exists jobs
+  add column if not exists form_field_wide jsonb default '[]';
 
 create table if not exists job_stages (
   id uuid primary key default uuid_generate_v4(),
@@ -102,6 +116,37 @@ create table if not exists job_stages (
   unique (job_id,position)
 );
 
+create table if not exists job_metrics (
+  job_id uuid primary key references jobs(id) on delete cascade,
+  link_clicks int default 0
+);
+
+-- Scripts de entrevista/roteiro
+create table if not exists job_scripts (
+  id uuid primary key default uuid_generate_v4(),
+  job_id uuid not null references jobs(id) on delete cascade,
+  name text not null,
+  content text default '',
+  softskills jsonb not null default '[]',
+  cultural_fit jsonb not null default '[]'
+);
+
+-- Formulários salvos
+create table if not exists job_form_configs (
+  id uuid primary key default uuid_generate_v4(),
+  job_id uuid not null references jobs(id) on delete cascade,
+  name text not null,
+  config jsonb not null default '[]'
+);
+
+create or replace function increment_job_link_click(j uuid)
+returns void as $$
+  insert into job_metrics(job_id, link_clicks)
+  values (j, 1)
+  on conflict (job_id)
+    do update set link_clicks = job_metrics.link_clicks + 1;
+$$ language sql;
+
 -- Applications
 create table if not exists applications (
   id uuid primary key default uuid_generate_v4(),
@@ -112,12 +157,16 @@ create table if not exists applications (
   applied_at timestamptz default now(),
   source candidate_source,
   notes text,
+  custom_answers jsonb default '{}',
   unique (job_id,talent_id)
 );
 
 -- Ensure legacy installations have the stage reference
 alter table if exists applications
   add column if not exists stage_id uuid references job_stages(id);
+
+alter table if exists applications
+  add column if not exists custom_answers jsonb default '{}';
 
 create table if not exists application_stage_history (
   id uuid primary key default uuid_generate_v4(),
@@ -130,6 +179,14 @@ create table if not exists application_stage_history (
   note text,
   due_at timestamptz,
   breached_at timestamptz
+);
+
+create table if not exists application_stage_dates (
+  application_id uuid not null references applications(id) on delete cascade,
+  stage_id uuid not null references job_stages(id) on delete cascade,
+  day_in date not null,
+  day_out date,
+  primary key (application_id, stage_id)
 );
 
 create table if not exists application_events (
@@ -162,8 +219,11 @@ alter table jobs enable row level security;
 alter table job_stages enable row level security;
 alter table applications enable row level security;
 alter table application_stage_history enable row level security;
+alter table application_stage_dates enable row level security;
 alter table application_events enable row level security;
 alter table reports_cache enable row level security;
+alter table job_scripts enable row level security;
+alter table job_form_configs enable row level security;
 
 -- Basic company isolation policies
 create policy company_iso on talents using (company_id = (auth.jwt() ->> 'company_id')::uuid) with check (company_id = (auth.jwt() ->> 'company_id')::uuid);
@@ -173,17 +233,24 @@ create policy company_iso on jobs using (company_id = (auth.jwt() ->> 'company_i
 create policy company_iso on job_stages using (company_id = (auth.jwt() ->> 'company_id')::uuid) with check (company_id = (auth.jwt() ->> 'company_id')::uuid);
 create policy company_iso on applications using (company_id = (auth.jwt() ->> 'company_id')::uuid) with check (company_id = (auth.jwt() ->> 'company_id')::uuid);
 create policy company_iso on application_stage_history using (exists (select 1 from applications a where a.id = application_stage_history.application_id and a.company_id = (auth.jwt() ->> 'company_id')::uuid));
+create policy company_iso on application_stage_dates using (exists (select 1 from applications a where a.id = application_stage_dates.application_id and a.company_id = (auth.jwt() ->> 'company_id')::uuid));
 create policy company_iso on application_events using (company_id = (auth.jwt() ->> 'company_id')::uuid) with check (company_id = (auth.jwt() ->> 'company_id')::uuid);
 create policy company_iso on reports_cache using (company_id = (auth.jwt() ->> 'company_id')::uuid) with check (company_id = (auth.jwt() ->> 'company_id')::uuid);
+create policy company_iso on job_scripts using (exists (select 1 from jobs j where j.id = job_scripts.job_id and j.company_id = (auth.jwt() ->> 'company_id')::uuid)) with check (exists (select 1 from jobs j where j.id = job_scripts.job_id and j.company_id = (auth.jwt() ->> 'company_id')::uuid));
+create policy company_iso on job_form_configs using (exists (select 1 from jobs j where j.id = job_form_configs.job_id and j.company_id = (auth.jwt() ->> 'company_id')::uuid)) with check (exists (select 1 from jobs j where j.id = job_form_configs.job_id and j.company_id = (auth.jwt() ->> 'company_id')::uuid));
 
 -- Role based write policies
 create policy talents_write on talents for all using (auth.jwt() ->> 'company_role' in ('admin','recruiter','manager') and company_id = (auth.jwt() ->> 'company_id')::uuid);
 create policy jobs_write on jobs for all using (auth.jwt() ->> 'company_role' in ('admin','recruiter','manager') and company_id = (auth.jwt() ->> 'company_id')::uuid);
 create policy job_stages_write on job_stages for all using (auth.jwt() ->> 'company_role' in ('admin','recruiter','manager') and company_id = (auth.jwt() ->> 'company_id')::uuid);
 create policy applications_write on applications for all using (auth.jwt() ->> 'company_role' in ('admin','recruiter','manager') and company_id = (auth.jwt() ->> 'company_id')::uuid);
+create policy job_scripts_write on job_scripts for all using (auth.jwt() ->> 'company_role' in ('admin','recruiter','manager') and exists (select 1 from jobs j where j.id = job_scripts.job_id and j.company_id = (auth.jwt() ->> 'company_id')::uuid));
+create policy job_form_configs_write on job_form_configs for all using (auth.jwt() ->> 'company_role' in ('admin','recruiter','manager') and exists (select 1 from jobs j where j.id = job_form_configs.job_id and j.company_id = (auth.jwt() ->> 'company_id')::uuid));
 
 -- Read-only policy for all roles
 create policy read_all on talents for select using (company_id = (auth.jwt() ->> 'company_id')::uuid);
 create policy read_all on jobs for select using (company_id = (auth.jwt() ->> 'company_id')::uuid);
 create policy read_all on job_stages for select using (company_id = (auth.jwt() ->> 'company_id')::uuid);
 create policy read_all on applications for select using (company_id = (auth.jwt() ->> 'company_id')::uuid);
+create policy read_all on job_scripts for select using (exists (select 1 from jobs j where j.id = job_scripts.job_id and j.company_id = (auth.jwt() ->> 'company_id')::uuid));
+create policy read_all on job_form_configs for select using (exists (select 1 from jobs j where j.id = job_form_configs.job_id and j.company_id = (auth.jwt() ->> 'company_id')::uuid));


### PR DESCRIPTION
## Summary
- allow companies to define custom application fields and store candidate answers
- render custom fields on the public apply form with support for multiple input types and configurable widths
- persist custom field definitions and responses via new JSON columns on jobs and applications
- add toggles to enable/disable standard and custom fields on job forms and only render enabled fields on public applications
- unify form field settings with drag-and-drop ordering and single-save workflow
- fix type error by ensuring newly added custom fields include required `enabled` flag
- present form-field settings as draggable cards with right-aligned toggles and inline delete, while the public form mirrors the two-column layout
- allow certain form fields to span the full width via new `jobs.form_field_wide` column and toggle, reflected on the public application form
- show job form fields and custom answers inside the talent modal so recruiters can review or edit any response
- fix built-in field typing in talent modal to avoid Next.js build failures
- surface all job fields in the talent modal regardless of visibility and expand the status selector to span the full width
- track candidate stage timing and link clicks for metrics, exposing a funnel chart and time-to-fill insights
- add Roteiro tab with rich text editor, soft skills and cultural fit criteria, and per-job script storage
- fix broken Roteiro tab imports so Next.js can resolve UI components
- export Card subcomponents so the Roteiro tab compiles during builds
- enhance Roteiro editor with selection-aware toolbar offering headings, lists, underline, and strikethrough formatting
- allow heading buttons to toggle off and remove quote/link controls from the Roteiro toolbar
- allow saving and loading named form layouts on the Divulgação tab via new `job_form_configs` table
- apply selected saved form layouts to job records so both public forms and talent modals reflect the chosen field order and widths

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit` *(Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ac63d41c88832dae428256b68eda1c