### PR TITLE
Refactor users page with tabbed CRUD layout

### DIFF
--- a/components/FieldPermissionsModal.tsx
+++ b/components/FieldPermissionsModal.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabaseClient';
+import { Button } from './ui/button';
+import { X } from 'lucide-react';
+
+interface FieldPerm {
+  view: boolean;
+  edit: boolean;
+  delete: boolean;
+}
+
+interface Props {
+  open: boolean;
+  table: string;
+  value: { [field: string]: FieldPerm };
+  onClose: () => void;
+  onSave: (value: { [field: string]: FieldPerm }) => void;
+}
+
+const fieldLabels: Record<string, string> = {
+  id: 'ID',
+  company_id: 'ID da empresa',
+  name: 'Nome',
+  email: 'E-mail',
+  phone: 'Telefone',
+  cpf: 'CPF',
+  birth_date: 'Data de nascimento',
+  street: 'Rua',
+  city: 'Cidade',
+  state: 'Estado',
+  zip: 'CEP',
+  position: 'Cargo',
+  department: 'Departamento',
+  unit: 'Unidade',
+  salary: 'Salário',
+  hire_date: 'Data de contratação',
+  termination_date: 'Data de demissão',
+  termination_reason: 'Motivo da demissão',
+  status: 'Status',
+  gender: 'Gênero',
+  emergency_contact_name: 'Nome do contato de emergência',
+  emergency_contact_phone: 'Telefone do contato de emergência',
+  emergency_contact_relation: 'Parentesco do contato de emergência',
+  resume_url: 'URL do currículo',
+  comments: 'Comentários',
+  custom_fields: 'Campos personalizados',
+  created_at: 'Criado em',
+};
+
+export default function FieldPermissionsModal({ open, table, value, onClose, onSave }: Props) {
+  const [fields, setFields] = useState<string[]>([]);
+  const [perms, setPerms] = useState<{ [field: string]: FieldPerm }>({});
+
+  useEffect(() => {
+    if (!open) return;
+    const load = async () => {
+      const { data } = await supabase.from(table).select('*').limit(1);
+      const cols = data && data.length ? Object.keys(data[0]) : [];
+      const init: Record<string, FieldPerm> = {};
+      cols.forEach((c) => {
+        init[c] = (value && value[c]) || { view: true, edit: false, delete: false };
+      });
+      setFields(cols);
+      setPerms(init);
+    };
+    load();
+  }, [open, table, value]);
+
+  const toggle = (field: string, key: keyof FieldPerm) => {
+    setPerms({
+      ...perms,
+      [field]: { ...perms[field], [key]: !perms[field][key] },
+    });
+  };
+
+  const allSelected = (key: keyof FieldPerm) => fields.every((f) => perms[f]?.[key]);
+  const toggleAll = (key: keyof FieldPerm) => {
+    const checked = !allSelected(key);
+    const next: Record<string, FieldPerm> = {};
+    fields.forEach((f) => {
+      next[f] = { ...perms[f], [key]: checked };
+    });
+    setPerms(next);
+  };
+
+  const labelFor = (field: string) => fieldLabels[field] || field.replace(/_/g, ' ');
+
+  const handleSave = () => {
+    onSave(perms);
+    onClose();
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white rounded p-4 w-full max-w-lg max-h-[80vh] overflow-y-auto">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-bold">Permissões de Campos</h2>
+          <button onClick={onClose} className="p-1 rounded hover:bg-gray-100">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="space-y-2 mb-4">
+          <div className="flex items-center gap-2 font-semibold">
+            <span className="flex-1">Campo</span>
+            <label className="flex items-center gap-1">
+              <input
+                type="checkbox"
+                checked={allSelected('view')}
+                onChange={() => toggleAll('view')}
+              />
+              Ver
+            </label>
+            <label className="flex items-center gap-1">
+              <input
+                type="checkbox"
+                checked={allSelected('edit')}
+                onChange={() => toggleAll('edit')}
+              />
+              Editar
+            </label>
+            <label className="flex items-center gap-1">
+              <input
+                type="checkbox"
+                checked={allSelected('delete')}
+                onChange={() => toggleAll('delete')}
+              />
+              Deletar
+            </label>
+          </div>
+          {fields.map((f) => (
+            <div key={f} className="flex items-center gap-2">
+              <span className="flex-1 capitalize">{labelFor(f)}</span>
+              <label className="flex items-center gap-1">
+                <input
+                  type="checkbox"
+                  checked={perms[f]?.view}
+                  onChange={() => toggle(f, 'view')}
+                />
+                Ver
+              </label>
+              <label className="flex items-center gap-1">
+                <input
+                  type="checkbox"
+                  checked={perms[f]?.edit}
+                  onChange={() => toggle(f, 'edit')}
+                />
+                Editar
+              </label>
+              <label className="flex items-center gap-1">
+                <input
+                  type="checkbox"
+                  checked={perms[f]?.delete}
+                  onChange={() => toggle(f, 'delete')}
+                />
+                Deletar
+              </label>
+            </div>
+          ))}
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" onClick={onClose}>
+            Cancelar
+          </Button>
+          <Button type="button" onClick={handleSave}>
+            Salvar
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ModulePermissionCard.tsx
+++ b/components/ModulePermissionCard.tsx
@@ -1,0 +1,34 @@
+import { Button } from './ui/button';
+
+interface Props {
+  label: string;
+  enabled: boolean;
+  onToggle: (value: boolean) => void;
+  onConfig?: () => void;
+}
+
+export default function ModulePermissionCard({ label, enabled, onToggle, onConfig }: Props) {
+  return (
+    <div className="border rounded p-3 flex flex-col gap-2 w-48">
+      <div className="flex items-center justify-between">
+        <span>{label}</span>
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => onToggle(e.target.checked)}
+        />
+      </div>
+      {onConfig && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onConfig}
+          disabled={!enabled}
+        >
+          Configurar
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -5,10 +5,19 @@ import { cn } from '../lib/utils';
 import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
 
+const defaultScopes = {
+  dashboard: true,
+  employees: true,
+  recruitment: true,
+  metrics: true,
+  users: true,
+};
+
 export default function Sidebar() {
   const router = useRouter();
   const [menuOpen, setMenuOpen] = useState(false);
   const [profile, setProfile] = useState<{ name: string; email: string } | null>(null);
+  const [scopes, setScopes] = useState<{ [key: string]: boolean }>(defaultScopes);
 
   useEffect(() => {
     supabase.auth.getUser().then(async ({ data }) => {
@@ -25,11 +34,12 @@ export default function Sidebar() {
       }
       const { data: companyUser } = await supabase
         .from('companies_users')
-        .select('name,email')
+        .select('name,email,scopes')
         .eq('user_id', user.id)
         .maybeSingle();
       if (companyUser) {
         setProfile(companyUser);
+        setScopes({ ...defaultScopes, ...companyUser.scopes });
         return;
       }
       const { data: unitUser } = await supabase
@@ -42,18 +52,20 @@ export default function Sidebar() {
   }, []);
 
   const links = [
-    { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
-    { href: '/employees', label: 'Funcionários', icon: Users },
-    { href: '/recruitment', label: 'Recrutamento & Seleção', icon: Briefcase },
-    { href: '/metrics', label: 'Métricas', icon: BarChart3 },
-    { href: '/users', label: 'Usuários & Permissões', icon: UserCog },
+    { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard, scope: 'dashboard' },
+    { href: '/employees', label: 'Funcionários', icon: Users, scope: 'employees' },
+    { href: '/recruitment', label: 'Recrutamento & Seleção', icon: Briefcase, scope: 'recruitment' },
+    { href: '/metrics', label: 'Métricas', icon: BarChart3, scope: 'metrics' },
+    { href: '/users', label: 'Usuários & Permissões', icon: UserCog, scope: 'users' },
   ];
 
   return (
     <aside className="w-64 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 min-h-screen p-6 flex flex-col">
       <h2 className="text-2xl font-bold text-brand mb-8">Constiva</h2>
       <nav className="flex flex-col space-y-1">
-        {links.map(({ href, label, icon: Icon }) => (
+        {links
+          .filter(({ scope }) => scopes[scope] !== false)
+          .map(({ href, label, icon: Icon }) => (
           <Link
             key={href}
             href={href}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,11 +1,54 @@
 import type { AppProps } from 'next/app';
 import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { supabase } from '../lib/supabaseClient';
 import '../styles/globals.css';
 
+const defaultScopes = {
+  dashboard: true,
+  employees: true,
+  recruitment: true,
+  metrics: true,
+  users: true,
+};
+
+const routeScopes: Record<string, string> = {
+  '/dashboard': 'dashboard',
+  '/employees': 'employees',
+  '/recruitment': 'recruitment',
+  '/metrics': 'metrics',
+  '/users': 'users',
+};
+
 export default function MyApp({ Component, pageProps }: AppProps) {
+  const router = useRouter();
+
   useEffect(() => {
     const dark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     document.documentElement.classList.toggle('dark', dark);
   }, []);
+
+  useEffect(() => {
+    const check = async () => {
+      const { data: session } = await supabase.auth.getSession();
+      const user = session.session?.user;
+      if (!user) return;
+      const { data: compUser } = await supabase
+        .from('companies_users')
+        .select('scopes')
+        .eq('user_id', user.id)
+        .maybeSingle();
+      const scopes = { ...defaultScopes, ...(compUser?.scopes || {}) };
+      const scopeKey = Object.entries(routeScopes).find(([path]) =>
+        router.pathname.startsWith(path)
+      )?.[1];
+      if (scopeKey && scopes[scopeKey] === false) {
+        const fallback = '/dashboard';
+        router.replace(router.pathname === fallback ? '/' : fallback);
+      }
+    };
+    check();
+  }, [router.pathname]);
+
   return <Component {...pageProps} />;
 }

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -1,11 +1,17 @@
 import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
 
+interface FieldPerm {
+  view: boolean;
+  edit: boolean;
+  delete: boolean;
+}
+
 interface Profile {
   name: string | null;
   email: string | null;
   role: string;
-  allowed_fields: string[];
+  allowed_fields: { [table: string]: { [field: string]: FieldPerm } };
 }
 
 export default function AccountPage() {
@@ -26,7 +32,10 @@ export default function AccountPage() {
           name: companyUser.name,
           email: companyUser.email,
           role: companyUser.role,
-          allowed_fields: companyUser.allowed_fields || [],
+          allowed_fields:
+            typeof companyUser.allowed_fields === 'string'
+              ? JSON.parse(companyUser.allowed_fields)
+              : companyUser.allowed_fields || {},
         });
         return;
       }
@@ -40,7 +49,7 @@ export default function AccountPage() {
           name: unitUser.name,
           email: unitUser.email,
           role: 'unit',
-          allowed_fields: [],
+          allowed_fields: {},
         });
         return;
       }
@@ -54,7 +63,7 @@ export default function AccountPage() {
           name: baseUser.name,
           email: baseUser.email,
           role: 'admin',
-          allowed_fields: [],
+          allowed_fields: {},
         });
       }
     }
@@ -70,16 +79,26 @@ export default function AccountPage() {
           <p><span className="font-medium">Nome:</span> {profile.name}</p>
           <p><span className="font-medium">Email:</span> {profile.email}</p>
           <p><span className="font-medium">Papel:</span> {profile.role}</p>
-          {profile.allowed_fields.length > 0 && (
-            <div>
-              <p className="font-medium">Campos que posso editar:</p>
-              <ul className="list-disc list-inside">
-                {profile.allowed_fields.map((f) => (
-                  <li key={f}>{f}</li>
-                ))}
-              </ul>
-            </div>
-          )}
+      {profile.allowed_fields &&
+        Object.keys(profile.allowed_fields).length > 0 && (
+          <div>
+            <p className="font-medium">Permissões de campos:</p>
+            {Object.entries(profile.allowed_fields).map(([table, fields]) => (
+              <div key={table} className="mt-2">
+                <p className="font-medium">{table}</p>
+                <ul className="list-disc list-inside">
+                  {Object.entries(fields as any).map(([f, perms]: any) => (
+                    <li key={f}>
+                      {f}: {['view', 'edit', 'delete']
+                        .filter((k) => perms[k])
+                        .join(', ')}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
         </div>
       )}
     </div>

--- a/pages/api/company-users.ts
+++ b/pages/api/company-users.ts
@@ -8,7 +8,17 @@ const supabase = createClient(supabaseUrl, serviceRoleKey);
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'POST') {
-    const { email, password, name, phone, position, role, scopes, company_id } = req.body;
+    const {
+      email,
+      password,
+      name,
+      phone,
+      position,
+      role,
+      scopes,
+      allowed_fields,
+      company_id,
+    } = req.body;
 
     const { data: userData, error: authError } = await supabase.auth.admin.createUser({
       email,
@@ -32,21 +42,55 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(400).json({ error: profileError.message });
     }
 
+    const allowedFieldsPayload =
+      allowed_fields && Object.keys(allowed_fields).length > 0
+        ? allowed_fields
+        : null;
+
     const { data: companyUser, error: insertError } = await supabase
       .from('companies_users')
-      .insert({ company_id, user_id: userId, name, email, phone, position, role, scopes })
-      .select('user_id,name,email,phone,position,role,scopes')
+      .insert({
+        company_id,
+        user_id: userId,
+        name,
+        email,
+        phone,
+        position,
+        role,
+        scopes,
+        allowed_fields: allowedFieldsPayload,
+      })
+      .select('user_id,name,email,phone,position,role,scopes,allowed_fields')
       .single();
 
     if (insertError) {
       return res.status(400).json({ error: insertError.message });
     }
 
-    return res.status(200).json({ user: companyUser });
+    const parsedUser = {
+      ...companyUser,
+      allowed_fields:
+        typeof companyUser.allowed_fields === 'string'
+          ? JSON.parse(companyUser.allowed_fields)
+          : companyUser.allowed_fields,
+    };
+
+    return res.status(200).json({ user: parsedUser });
   }
 
   if (req.method === 'PUT') {
-    const { user_id, company_id, name, email, phone, position, password, role, scopes } = req.body;
+    const {
+      user_id,
+      company_id,
+      name,
+      email,
+      phone,
+      position,
+      password,
+      role,
+      scopes,
+      allowed_fields,
+    } = req.body;
 
     const updateAuthPayload: any = {
       email,
@@ -76,19 +120,40 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(400).json({ error: updateProfileError.message });
     }
 
+    const allowedFieldsPayload =
+      allowed_fields && Object.keys(allowed_fields).length > 0
+        ? allowed_fields
+        : null;
+
     const { data: updatedUser, error: updateError } = await supabase
       .from('companies_users')
-      .update({ name, email, phone, position, role, scopes })
+      .update({
+        name,
+        email,
+        phone,
+        position,
+        role,
+        scopes,
+        allowed_fields: allowedFieldsPayload,
+      })
       .eq('company_id', company_id)
       .eq('user_id', user_id)
-      .select('user_id,name,email,phone,position,role,scopes')
+      .select('user_id,name,email,phone,position,role,scopes,allowed_fields')
       .single();
 
     if (updateError) {
       return res.status(400).json({ error: updateError.message });
     }
 
-    return res.status(200).json({ user: updatedUser });
+    const parsedUser = {
+      ...updatedUser,
+      allowed_fields:
+        typeof updatedUser.allowed_fields === 'string'
+          ? JSON.parse(updatedUser.allowed_fields)
+          : updatedUser.allowed_fields,
+    };
+
+    return res.status(200).json({ user: parsedUser });
   }
 
   if (req.method === 'DELETE') {

--- a/pages/users/index.tsx
+++ b/pages/users/index.tsx
@@ -4,6 +4,8 @@ import { supabase } from '../../lib/supabaseClient';
 import { Input } from '../../components/ui/input';
 import { Button } from '../../components/ui/button';
 import PositionSidebar from '../../components/PositionSidebar';
+import ModulePermissionCard from '../../components/ModulePermissionCard';
+import FieldPermissionsModal from '../../components/FieldPermissionsModal';
 
 interface CompanyUser {
   user_id: string;
@@ -12,7 +14,8 @@ interface CompanyUser {
   phone: string;
   position: string | null;
   role: string;
-  scopes: { [key: string]: boolean };
+  scopes: { [key: string]: any };
+  allowed_fields?: any;
 }
 
 interface CompanyUnit {
@@ -22,6 +25,14 @@ interface CompanyUnit {
   phone: string;
 }
 
+const defaultScopes = {
+  dashboard: true,
+  employees: true,
+  recruitment: true,
+  metrics: true,
+  users: true,
+};
+
 export default function CompanyUsersPage() {
   const [tab, setTab] = useState<'users' | 'units'>('users');
   const [users, setUsers] = useState<CompanyUser[]>([]);
@@ -29,6 +40,9 @@ export default function CompanyUsersPage() {
   const [companyId, setCompanyId] = useState('');
   const [positions, setPositions] = useState<string[]>([]);
   const [posOpen, setPosOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [creatingUser, setCreatingUser] = useState(false);
+  const [creatingUnit, setCreatingUnit] = useState(false);
 
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -36,8 +50,10 @@ export default function CompanyUsersPage() {
   const [password, setPassword] = useState('');
   const [position, setPosition] = useState('');
   const [role, setRole] = useState('viewer');
-  const [scopes, setScopes] = useState<{ [key: string]: boolean }>({});
+  const [scopes, setScopes] = useState<any>({ ...defaultScopes });
+  const [allowedFields, setAllowedFields] = useState<any>({ employees: {} });
   const [editingId, setEditingId] = useState<string | null>(null);
+  const [fieldsOpen, setFieldsOpen] = useState(false);
 
   const [uName, setUName] = useState('');
   const [uEmail, setUEmail] = useState('');
@@ -46,9 +62,11 @@ export default function CompanyUsersPage() {
   const [unitEditingId, setUnitEditingId] = useState<string | null>(null);
 
   const scopeLabels: Record<string, string> = {
+    dashboard: 'Dashboard',
     employees: 'Funcionários',
-    metrics: 'Métricas',
     recruitment: 'R&S',
+    metrics: 'Métricas',
+    users: 'Usuários',
   };
 
   const roleLabels: Record<string, string> = {
@@ -58,9 +76,9 @@ export default function CompanyUsersPage() {
     viewer: 'Visualizador',
   };
 
-  const formatScopes = (s: { [key: string]: boolean }) =>
-    Object.keys(s || {})
-      .filter((k) => s[k])
+  const formatScopes = (s: { [key: string]: any }) =>
+    Object.keys(defaultScopes)
+      .filter((k) => (s || {})[k] !== false)
       .map((k) => scopeLabels[k] || k)
       .join(', ');
 
@@ -86,9 +104,17 @@ export default function CompanyUsersPage() {
 
       const { data: companyUsers } = await supabase
         .from('companies_users')
-        .select('user_id,name,email,phone,position,role,scopes')
+        .select('user_id,name,email,phone,position,role,scopes,allowed_fields')
         .eq('company_id', compId);
-      setUsers(companyUsers || []);
+      setUsers(
+        (companyUsers || []).map((u: any) => ({
+          ...u,
+          allowed_fields:
+            typeof u.allowed_fields === 'string'
+              ? JSON.parse(u.allowed_fields)
+              : u.allowed_fields,
+        }))
+      );
 
       const { data: companyUnits } = await supabase
         .from('companies_units')
@@ -98,6 +124,50 @@ export default function CompanyUsersPage() {
     };
     load();
   }, []);
+
+  const startCreateUser = () => {
+    setCreatingUser(true);
+    setEditingId(null);
+    setName('');
+    setEmail('');
+    setPhone('');
+    setPassword('');
+    setPosition('');
+    setRole('viewer');
+    setScopes({ ...defaultScopes });
+    setAllowedFields({ employees: {} });
+  };
+
+  const closeUserForm = () => {
+    setCreatingUser(false);
+    setEditingId(null);
+    setName('');
+    setEmail('');
+    setPhone('');
+    setPassword('');
+    setPosition('');
+    setRole('viewer');
+    setScopes({ ...defaultScopes });
+    setAllowedFields({ employees: {} });
+  };
+
+  const startCreateUnit = () => {
+    setCreatingUnit(true);
+    setUnitEditingId(null);
+    setUName('');
+    setUEmail('');
+    setUPhone('');
+    setUPassword('');
+  };
+
+  const closeUnitForm = () => {
+    setCreatingUnit(false);
+    setUnitEditingId(null);
+    setUName('');
+    setUEmail('');
+    setUPhone('');
+    setUPassword('');
+  };
 
   const saveUser = async () => {
     const method = editingId ? 'PUT' : 'POST';
@@ -113,6 +183,7 @@ export default function CompanyUsersPage() {
         position,
         role,
         scopes,
+        allowed_fields: allowedFields,
         company_id: companyId,
       }),
     });
@@ -120,30 +191,32 @@ export default function CompanyUsersPage() {
     if (data.error) {
       alert(data.error);
     } else {
+      const returned = {
+        ...data.user,
+        allowed_fields:
+          typeof data.user.allowed_fields === 'string'
+            ? JSON.parse(data.user.allowed_fields)
+            : data.user.allowed_fields,
+      };
       if (editingId) {
-        setUsers(users.map((u) => (u.user_id === editingId ? data.user : u)));
+        setUsers(users.map((u) => (u.user_id === editingId ? returned : u)));
       } else {
-        setUsers([...users, data.user]);
+        setUsers([...users, returned]);
       }
-      setEditingId(null);
-      setName('');
-      setEmail('');
-      setPhone('');
-      setPassword('');
-      setPosition('');
-      setRole('viewer');
-      setScopes({});
+      closeUserForm();
     }
   };
 
   const startEdit = (u: CompanyUser) => {
+    setCreatingUser(false);
     setEditingId(u.user_id);
     setName(u.name);
     setEmail(u.email);
     setPhone(u.phone);
     setPosition(u.position || '');
     setRole(u.role || 'viewer');
-    setScopes(u.scopes || {});
+    setScopes({ ...defaultScopes, ...(u.scopes || {}) });
+    setAllowedFields({ employees: {}, ...(u.allowed_fields || {}) });
   };
 
   const deleteUser = async (user_id: string) => {
@@ -158,6 +231,46 @@ export default function CompanyUsersPage() {
       alert(data.error);
     } else {
       setUsers(users.filter((u) => u.user_id !== user_id));
+      if (editingId === user_id) {
+        closeUserForm();
+      }
+    }
+  };
+
+  const handleFieldsSave = async (val: any) => {
+    const updated = { ...allowedFields, employees: val };
+    setAllowedFields(updated);
+    if (editingId) {
+      const res = await fetch('/api/company-users', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          user_id: editingId,
+          email,
+          name,
+          phone,
+          position,
+          role,
+          scopes,
+          allowed_fields: updated,
+          company_id: companyId,
+        }),
+      });
+      const data = await res.json();
+      if (data.error) {
+        alert(data.error);
+      } else {
+        const returned = {
+          ...data.user,
+          allowed_fields:
+            typeof data.user.allowed_fields === 'string'
+              ? JSON.parse(data.user.allowed_fields)
+              : data.user.allowed_fields,
+        };
+        setUsers(
+          users.map((u) => (u.user_id === editingId ? returned : u))
+        );
+      }
     }
   };
 
@@ -184,15 +297,12 @@ export default function CompanyUsersPage() {
       } else {
         setUnits([...units, data.user]);
       }
-      setUnitEditingId(null);
-      setUName('');
-      setUEmail('');
-      setUPhone('');
-      setUPassword('');
+      closeUnitForm();
     }
   };
 
   const startEditUnit = (u: CompanyUnit) => {
+    setCreatingUnit(false);
     setUnitEditingId(u.user_id);
     setUName(u.name);
     setUEmail(u.email);
@@ -211,207 +321,206 @@ export default function CompanyUsersPage() {
       alert(data.error);
     } else {
       setUnits(units.filter((u) => u.user_id !== user_id));
+      if (unitEditingId === user_id) {
+        closeUnitForm();
+      }
     }
   };
+
+  const filteredUsers = users.filter(
+    (u) =>
+      u.name.toLowerCase().includes(search.toLowerCase()) ||
+      u.email.toLowerCase().includes(search.toLowerCase())
+  );
+  const filteredUnits = units.filter(
+    (u) =>
+      u.name.toLowerCase().includes(search.toLowerCase()) ||
+      u.email.toLowerCase().includes(search.toLowerCase())
+  );
 
   return (
     <Layout>
       <div className="mb-8">
         <h1 className="text-2xl font-bold mb-4">Usuários & Permissões</h1>
-      <div className="mb-4 flex gap-2">
-        <Button variant={tab === 'users' ? 'default' : 'outline'} onClick={() => setTab('users')}>
-          Usuários
-        </Button>
-        <Button variant={tab === 'units' ? 'default' : 'outline'} onClick={() => setTab('units')}>
-          Unidades
-        </Button>
-      </div>
-      {tab === 'users' ? (
-        <>
-            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 mb-4">
-              <Input placeholder="Nome" value={name} onChange={(e) => setName(e.target.value)} />
-              <Input placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
-              <Input placeholder="Telefone" value={phone} onChange={(e) => setPhone(e.target.value)} />
-              <Input
-                placeholder="Senha"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-              />
-              <div className="flex items-center gap-2">
-                <select
-                  className="border p-2 rounded w-full"
-                  value={position}
-                  onChange={(e) => setPosition(e.target.value)}
+
+        <div className="mb-4 border-b flex">
+          <button
+            className={`px-4 py-2 -mb-px ${tab === 'users' ? 'border-b-2 border-black' : 'text-gray-500'}`}
+            onClick={() => {
+              setTab('users');
+              setSearch('');
+              setCreatingUser(false);
+              setCreatingUnit(false);
+              setEditingId(null);
+              setUnitEditingId(null);
+            }}
+          >
+            Usuários
+          </button>
+          <button
+            className={`px-4 py-2 -mb-px ${tab === 'units' ? 'border-b-2 border-black' : 'text-gray-500'}`}
+            onClick={() => {
+              setTab('units');
+              setSearch('');
+              setCreatingUser(false);
+              setCreatingUnit(false);
+              setEditingId(null);
+              setUnitEditingId(null);
+            }}
+          >
+            Unidades
+          </button>
+        </div>
+
+        <div className="flex gap-2 mb-4">
+          <Input
+            placeholder="Pesquisar"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <Button onClick={tab === 'users' ? startCreateUser : startCreateUnit}>
+            {tab === 'users' ? 'Criar usuário' : 'Criar unidade'}
+          </Button>
+        </div>
+
+        {tab === 'users' ? (
+          <div className="flex gap-4">
+            <div className="w-1/3 space-y-2">
+              {filteredUsers.map((u) => (
+                <div
+                  key={u.user_id}
+                  onClick={() => startEdit(u)}
+                  className={`border p-2 rounded cursor-pointer ${
+                    editingId === u.user_id && !creatingUser ? 'bg-gray-100' : ''
+                  }`}
                 >
-                  <option value="">Cargo</option>
-                  {positions.map((p) => (
-                    <option key={p} value={p}>
-                      {p}
-                    </option>
-                  ))}
-                </select>
-                <Button type="button" variant="outline" size="sm" onClick={() => setPosOpen(true)}>
-                  Cargos
-                </Button>
-              </div>
-              <select
-                className="border p-2 rounded w-full"
-                value={role}
-                onChange={(e) => setRole(e.target.value)}
-              >
-                <option value="admin">Administrador</option>
-                <option value="manager">Gestor</option>
-                <option value="recruiter">Recrutador</option>
-                <option value="viewer">Visualizador</option>
-              </select>
-              <div className="sm:col-span-2 lg:col-span-3 flex gap-4">
-                <label className="flex items-center gap-1">
-                  <input
-                    type="checkbox"
-                    checked={scopes.employees || false}
-                    onChange={(e) => setScopes({ ...scopes, employees: e.target.checked })}
-                  />
-                  Funcionários
-                </label>
-                <label className="flex items-center gap-1">
-                  <input
-                    type="checkbox"
-                    checked={scopes.metrics || false}
-                    onChange={(e) => setScopes({ ...scopes, metrics: e.target.checked })}
-                  />
-                  Métricas
-                </label>
-                <label className="flex items-center gap-1">
-                  <input
-                    type="checkbox"
-                    checked={scopes.recruitment || false}
-                    onChange={(e) =>
-                      setScopes({ ...scopes, recruitment: e.target.checked })
-                    }
-                  />
-                  R&S
-                </label>
-              </div>
-              <div className="sm:col-span-2 lg:col-span-3 flex gap-2">
-                <Button onClick={saveUser} disabled={!name || !email || (!password && !editingId)}>
-                  {editingId ? 'Salvar' : 'Adicionar'}
-                </Button>
-                {editingId && (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => {
-                      setEditingId(null);
-                      setName('');
-                      setEmail('');
-                      setPhone('');
-                      setPassword('');
-                      setPosition('');
-                      setRole('viewer');
-                      setScopes({});
-                    }}
-                  >
-                    Cancelar
-                  </Button>
-                )}
-              </div>
+                  <div className="font-semibold">{u.name}</div>
+                  <div className="text-sm text-gray-600">{u.email}</div>
+                  <div className="text-xs text-gray-500">
+                    {formatScopes(u.scopes)}
+                  </div>
+                </div>
+              ))}
             </div>
-            <table className="w-full text-left border">
-              <thead>
-                <tr className="border-b">
-                  <th className="p-2">Nome</th>
-                  <th className="p-2">Email</th>
-                  <th className="p-2">Telefone</th>
-                  <th className="p-2">Cargo</th>
-                  <th className="p-2">Papel</th>
-                  <th className="p-2">Módulos</th>
-                  <th className="p-2">Ações</th>
-                </tr>
-              </thead>
-              <tbody>
-                {users.map((u) => (
-                  <tr key={u.user_id} className="border-b">
-                    <td className="p-2">{u.name}</td>
-                    <td className="p-2">{u.email}</td>
-                    <td className="p-2">{u.phone}</td>
-                    <td className="p-2">{u.position}</td>
-                    <td className="p-2">{roleLabels[u.role] || u.role}</td>
-                    <td className="p-2">{formatScopes(u.scopes)}</td>
-                    <td className="p-2 flex gap-2">
-                      <Button size="sm" variant="outline" onClick={() => startEdit(u)}>
-                        Editar
-                      </Button>
-                      <Button size="sm" variant="destructive" onClick={() => deleteUser(u.user_id)}>
-                        Excluir
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </>
+            <div className="flex-1">
+              {(creatingUser || editingId) && (
+                <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                  <Input placeholder="Nome" value={name} onChange={(e) => setName(e.target.value)} />
+                  <Input placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+                  <Input placeholder="Telefone" value={phone} onChange={(e) => setPhone(e.target.value)} />
+                  <Input
+                    placeholder="Senha"
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                  />
+                  <div className="flex items-center gap-2">
+                    <select
+                      className="border p-2 rounded w-full"
+                      value={position}
+                      onChange={(e) => setPosition(e.target.value)}
+                    >
+                      <option value="">Cargo</option>
+                      {positions.map((p) => (
+                        <option key={p} value={p}>
+                          {p}
+                        </option>
+                      ))}
+                    </select>
+                    <Button type="button" variant="outline" size="sm" onClick={() => setPosOpen(true)}>
+                      Cargos
+                    </Button>
+                  </div>
+                  <select
+                    className="border p-2 rounded w-full"
+                    value={role}
+                    onChange={(e) => setRole(e.target.value)}
+                  >
+                    <option value="admin">Administrador</option>
+                    <option value="manager">Gestor</option>
+                    <option value="recruiter">Recrutador</option>
+                    <option value="viewer">Visualizador</option>
+                  </select>
+                  <div className="sm:col-span-2 lg:col-span-3 flex gap-4 flex-wrap">
+                    <ModulePermissionCard
+                      label="Dashboard"
+                      enabled={scopes.dashboard}
+                      onToggle={(v) => setScopes({ ...scopes, dashboard: v })}
+                    />
+                    <ModulePermissionCard
+                      label="Funcionários"
+                      enabled={scopes.employees}
+                      onToggle={(v) => setScopes({ ...scopes, employees: v })}
+                      onConfig={() => setFieldsOpen(true)}
+                    />
+                    <ModulePermissionCard
+                      label="R&S"
+                      enabled={scopes.recruitment}
+                      onToggle={(v) => setScopes({ ...scopes, recruitment: v })}
+                    />
+                    <ModulePermissionCard
+                      label="Métricas"
+                      enabled={scopes.metrics}
+                      onToggle={(v) => setScopes({ ...scopes, metrics: v })}
+                    />
+                    <ModulePermissionCard
+                      label="Usuários"
+                      enabled={scopes.users}
+                      onToggle={(v) => setScopes({ ...scopes, users: v })}
+                    />
+                  </div>
+                  <div className="sm:col-span-2 lg:col-span-3 flex gap-2">
+                    <Button onClick={saveUser} disabled={!name || !email || (!password && !editingId)}>
+                      {editingId ? 'Salvar' : 'Adicionar'}
+                    </Button>
+                    <Button type="button" variant="outline" onClick={closeUserForm}>
+                      Cancelar
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
         ) : (
-          <>
-            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 mb-4">
-              <Input placeholder="Nome" value={uName} onChange={(e) => setUName(e.target.value)} />
-              <Input placeholder="Email" value={uEmail} onChange={(e) => setUEmail(e.target.value)} />
-              <Input placeholder="Telefone" value={uPhone} onChange={(e) => setUPhone(e.target.value)} />
-              <Input
-                placeholder="Senha"
-                type="password"
-                value={uPassword}
-                onChange={(e) => setUPassword(e.target.value)}
-              />
-              <div className="sm:col-span-2 lg:col-span-3 flex gap-2">
-                <Button onClick={saveUnit} disabled={!uName || !uEmail || (!uPassword && !unitEditingId)}>
-                  {unitEditingId ? 'Salvar' : 'Adicionar'}
-                </Button>
-                {unitEditingId && (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => {
-                      setUnitEditingId(null);
-                      setUName('');
-                      setUEmail('');
-                      setUPhone('');
-                      setUPassword('');
-                    }}
-                  >
-                    Cancelar
-                  </Button>
-                )}
-              </div>
+          <div className="flex gap-4">
+            <div className="w-1/3 space-y-2">
+              {filteredUnits.map((u) => (
+                <div
+                  key={u.user_id}
+                  onClick={() => startEditUnit(u)}
+                  className={`border p-2 rounded cursor-pointer ${
+                    unitEditingId === u.user_id && !creatingUnit ? 'bg-gray-100' : ''
+                  }`}
+                >
+                  <div className="font-semibold">{u.name}</div>
+                  <div className="text-sm text-gray-600">{u.email}</div>
+                </div>
+              ))}
             </div>
-            <table className="w-full text-left border">
-              <thead>
-                <tr className="border-b">
-                  <th className="p-2">Nome</th>
-                  <th className="p-2">Email</th>
-                  <th className="p-2">Telefone</th>
-                  <th className="p-2">Ações</th>
-                </tr>
-              </thead>
-              <tbody>
-                {units.map((u) => (
-                  <tr key={u.user_id} className="border-b">
-                    <td className="p-2">{u.name}</td>
-                    <td className="p-2">{u.email}</td>
-                    <td className="p-2">{u.phone}</td>
-                    <td className="p-2 flex gap-2">
-                      <Button size="sm" variant="outline" onClick={() => startEditUnit(u)}>
-                        Editar
-                      </Button>
-                      <Button size="sm" variant="destructive" onClick={() => deleteUnit(u.user_id)}>
-                        Excluir
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </>
+            <div className="flex-1">
+              {(creatingUnit || unitEditingId) && (
+                <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                  <Input placeholder="Nome" value={uName} onChange={(e) => setUName(e.target.value)} />
+                  <Input placeholder="Email" value={uEmail} onChange={(e) => setUEmail(e.target.value)} />
+                  <Input placeholder="Telefone" value={uPhone} onChange={(e) => setUPhone(e.target.value)} />
+                  <Input
+                    placeholder="Senha"
+                    type="password"
+                    value={uPassword}
+                    onChange={(e) => setUPassword(e.target.value)}
+                  />
+                  <div className="sm:col-span-2 lg:col-span-3 flex gap-2">
+                    <Button onClick={saveUnit} disabled={!uName || !uEmail || (!uPassword && !unitEditingId)}>
+                      {unitEditingId ? 'Salvar' : 'Adicionar'}
+                    </Button>
+                    <Button type="button" variant="outline" onClick={closeUnitForm}>
+                      Cancelar
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
         )}
       </div>
       <PositionSidebar
@@ -424,6 +533,13 @@ export default function CompanyUsersPage() {
             .eq('company_id', companyId)
             .then(({ data }) => setPositions(data?.map((p: any) => p.name) || []));
         }}
+      />
+      <FieldPermissionsModal
+        open={fieldsOpen}
+        onClose={() => setFieldsOpen(false)}
+        table="employees"
+        value={allowedFields.employees || {}}
+        onSave={handleFieldsSave}
       />
     </Layout>
   );


### PR DESCRIPTION
## Summary
- Redesign the users page with tab navigation for users and units
- Add search bar and create button in top bar
- List existing entries as selectable cards with side-by-side edit form
- Introduce default-on access toggles for dashboard, employees, recruitment, metrics and users
- Filter sidebar links and redirect when a scope is disabled
- Replace simple scope checkboxes with card-based module toggles and a configuration modal
- Allow configuring employee field visibility, edit rights and delete access with select-all options and Portuguese labels
- Persist field-level permissions to `companies_users.allowed_fields` for future per-table configurations
- Fix persistence by JSON-serializing `allowed_fields` and seeding the modal from saved values
- Store `allowed_fields` as JSON instead of a serialized string to ensure database persistence
- Save field permission changes from the modal immediately to `companies_users.allowed_fields`

## Testing
- `npm test`
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f9e879ec832da4de8348a3df24b5