### PR TITLE
Refactor users page with tabbed CRUD layout

### DIFF
--- a/components/FieldPermissionsModal.tsx
+++ b/components/FieldPermissionsModal.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabaseClient';
+import { Button } from './ui/button';
+import { X } from 'lucide-react';
+import Switch from './ui/switch';
+
+interface Props {
+  open: boolean;
+  table: string;
+  value: { [field: string]: boolean };
+  onClose: () => void;
+  onSave: (value: { [field: string]: boolean }) => void;
+}
+
+const fieldLabels: Record<string, string> = {
+  id: 'ID',
+  company_id: 'ID da empresa',
+  name: 'Nome',
+  email: 'E-mail',
+  phone: 'Telefone',
+  cpf: 'CPF',
+  birth_date: 'Data de nascimento',
+  street: 'Rua',
+  city: 'Cidade',
+  state: 'Estado',
+  zip: 'CEP',
+  position: 'Cargo',
+  department: 'Departamento',
+  unit: 'Unidade',
+  salary: 'Salário',
+  hire_date: 'Data de contratação',
+  termination_date: 'Data de demissão',
+  termination_reason: 'Motivo da demissão',
+  status: 'Status',
+  gender: 'Gênero',
+  emergency_contact_name: 'Nome do contato de emergência',
+  emergency_contact_phone: 'Telefone do contato de emergência',
+  emergency_contact_relation: 'Parentesco do contato de emergência',
+  resume_url: 'URL do currículo',
+  comments: 'Comentários',
+  custom_fields: 'Campos personalizados',
+  created_at: 'Criado em',
+};
+
+export default function FieldPermissionsModal({ open, table, value, onClose, onSave }: Props) {
+  const [fields, setFields] = useState<string[]>([]);
+  const [perms, setPerms] = useState<{ [field: string]: boolean }>({});
+
+  useEffect(() => {
+    if (!open) return;
+    const load = async () => {
+      const { data } = await supabase.from(table).select('*').limit(1);
+      const cols = data && data.length ? Object.keys(data[0]) : [];
+      const init: Record<string, boolean> = {};
+      cols.forEach((c) => {
+        init[c] = value && typeof value[c] !== 'undefined' ? value[c] : true;
+      });
+      setFields(cols);
+      setPerms(init);
+    };
+    load();
+  }, [open, table, value]);
+
+  const toggle = (field: string) => {
+    setPerms({
+      ...perms,
+      [field]: !perms[field],
+    });
+  };
+
+  const labelFor = (field: string) => fieldLabels[field] || field.replace(/_/g, ' ');
+
+  const handleSave = () => {
+    onSave(perms);
+    onClose();
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white rounded p-4 w-full max-w-lg max-h-[80vh] overflow-y-auto">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-bold">Permissões de Campos</h2>
+          <button onClick={onClose} className="p-1 rounded hover:bg-gray-100">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="space-y-2 mb-4">
+          <div className="flex items-center gap-2 font-semibold">
+            <span className="flex-1">Campo</span>
+            <span>Ativo</span>
+          </div>
+          {fields.map((f) => (
+            <div key={f} className="flex items-center gap-2">
+              <span className="flex-1 capitalize">{labelFor(f)}</span>
+              <Switch checked={perms[f]} onChange={() => toggle(f)} />
+            </div>
+          ))}
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" onClick={onClose}>
+            Cancelar
+          </Button>
+          <Button type="button" onClick={handleSave}>
+            Salvar
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ModulePermissionCard.tsx
+++ b/components/ModulePermissionCard.tsx
@@ -1,0 +1,33 @@
+import Switch from './ui/switch';
+import { Button } from './ui/button';
+import { Cog } from 'lucide-react';
+
+interface Props {
+  label: string;
+  enabled: boolean;
+  onToggle: (value: boolean) => void;
+  onConfig?: () => void;
+}
+
+export default function ModulePermissionCard({ label, enabled, onToggle, onConfig }: Props) {
+  return (
+    <div className="border rounded p-3 flex items-center justify-between w-full">
+      <span>{label}</span>
+      <div className="flex items-center gap-2">
+        {onConfig && (
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            onClick={onConfig}
+            disabled={!enabled}
+            aria-label="Configurar"
+          >
+            <Cog className="h-4 w-4" />
+          </Button>
+        )}
+        <Switch checked={enabled} onChange={onToggle} />
+      </div>
+    </div>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -5,10 +5,19 @@ import { cn } from '../lib/utils';
 import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabaseClient';
 
+const defaultScopes = {
+  dashboard: true,
+  employees: true,
+  recruitment: true,
+  metrics: true,
+  users: true,
+};
+
 export default function Sidebar() {
   const router = useRouter();
   const [menuOpen, setMenuOpen] = useState(false);
   const [profile, setProfile] = useState<{ name: string; email: string } | null>(null);
+  const [scopes, setScopes] = useState<{ [key: string]: boolean }>(defaultScopes);
 
   useEffect(() => {
     supabase.auth.getUser().then(async ({ data }) => {
@@ -25,11 +34,12 @@ export default function Sidebar() {
       }
       const { data: companyUser } = await supabase
         .from('companies_users')
-        .select('name,email')
+        .select('name,email,scopes')
         .eq('user_id', user.id)
         .maybeSingle();
       if (companyUser) {
         setProfile(companyUser);
+        setScopes({ ...defaultScopes, ...companyUser.scopes });
         return;
       }
       const { data: unitUser } = await supabase
@@ -42,18 +52,20 @@ export default function Sidebar() {
   }, []);
 
   const links = [
-    { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
-    { href: '/employees', label: 'Funcionários', icon: Users },
-    { href: '/recruitment', label: 'Recrutamento & Seleção', icon: Briefcase },
-    { href: '/metrics', label: 'Métricas', icon: BarChart3 },
-    { href: '/users', label: 'Usuários & Permissões', icon: UserCog },
+    { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard, scope: 'dashboard' },
+    { href: '/employees', label: 'Funcionários', icon: Users, scope: 'employees' },
+    { href: '/recruitment', label: 'Recrutamento & Seleção', icon: Briefcase, scope: 'recruitment' },
+    { href: '/metrics', label: 'Métricas', icon: BarChart3, scope: 'metrics' },
+    { href: '/users', label: 'Usuários & Permissões', icon: UserCog, scope: 'users' },
   ];
 
   return (
     <aside className="w-64 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 min-h-screen p-6 flex flex-col">
       <h2 className="text-2xl font-bold text-brand mb-8">Constiva</h2>
       <nav className="flex flex-col space-y-1">
-        {links.map(({ href, label, icon: Icon }) => (
+        {links
+          .filter(({ scope }) => scopes[scope] !== false)
+          .map(({ href, label, icon: Icon }) => (
           <Link
             key={href}
             href={href}

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface SwitchProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+export default function Switch({ checked, onChange }: SwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+      className={`w-10 h-6 rounded-full p-1 flex items-center transition-colors ${
+        checked ? 'bg-purple-600' : 'bg-gray-300'
+      }`}
+    >
+      <span
+        className={`bg-white w-4 h-4 rounded-full transform transition ${
+          checked ? 'translate-x-4' : ''
+        }`}
+      />
+    </button>
+  );
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,11 +1,54 @@
 import type { AppProps } from 'next/app';
 import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { supabase } from '../lib/supabaseClient';
 import '../styles/globals.css';
 
+const defaultScopes = {
+  dashboard: true,
+  employees: true,
+  recruitment: true,
+  metrics: true,
+  users: true,
+};
+
+const routeScopes: Record<string, string> = {
+  '/dashboard': 'dashboard',
+  '/employees': 'employees',
+  '/recruitment': 'recruitment',
+  '/metrics': 'metrics',
+  '/users': 'users',
+};
+
 export default function MyApp({ Component, pageProps }: AppProps) {
+  const router = useRouter();
+
   useEffect(() => {
     const dark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     document.documentElement.classList.toggle('dark', dark);
   }, []);
+
+  useEffect(() => {
+    const check = async () => {
+      const { data: session } = await supabase.auth.getSession();
+      const user = session.session?.user;
+      if (!user) return;
+      const { data: compUser } = await supabase
+        .from('companies_users')
+        .select('scopes')
+        .eq('user_id', user.id)
+        .maybeSingle();
+      const scopes = { ...defaultScopes, ...(compUser?.scopes || {}) };
+      const scopeKey = Object.entries(routeScopes).find(([path]) =>
+        router.pathname.startsWith(path)
+      )?.[1];
+      if (scopeKey && scopes[scopeKey] === false) {
+        const fallback = '/dashboard';
+        router.replace(router.pathname === fallback ? '/' : fallback);
+      }
+    };
+    check();
+  }, [router.pathname]);
+
   return <Component {...pageProps} />;
 }

--- a/pages/account.tsx
+++ b/pages/account.tsx
@@ -5,7 +5,7 @@ interface Profile {
   name: string | null;
   email: string | null;
   role: string;
-  allowed_fields: string[];
+  allowed_fields: { [table: string]: { [field: string]: boolean } };
 }
 
 export default function AccountPage() {
@@ -26,7 +26,10 @@ export default function AccountPage() {
           name: companyUser.name,
           email: companyUser.email,
           role: companyUser.role,
-          allowed_fields: companyUser.allowed_fields || [],
+          allowed_fields:
+            typeof companyUser.allowed_fields === 'string'
+              ? JSON.parse(companyUser.allowed_fields)
+              : companyUser.allowed_fields || {},
         });
         return;
       }
@@ -40,7 +43,7 @@ export default function AccountPage() {
           name: unitUser.name,
           email: unitUser.email,
           role: 'unit',
-          allowed_fields: [],
+          allowed_fields: {},
         });
         return;
       }
@@ -54,7 +57,7 @@ export default function AccountPage() {
           name: baseUser.name,
           email: baseUser.email,
           role: 'admin',
-          allowed_fields: [],
+          allowed_fields: {},
         });
       }
     }
@@ -70,16 +73,22 @@ export default function AccountPage() {
           <p><span className="font-medium">Nome:</span> {profile.name}</p>
           <p><span className="font-medium">Email:</span> {profile.email}</p>
           <p><span className="font-medium">Papel:</span> {profile.role}</p>
-          {profile.allowed_fields.length > 0 && (
-            <div>
-              <p className="font-medium">Campos que posso editar:</p>
-              <ul className="list-disc list-inside">
-                {profile.allowed_fields.map((f) => (
-                  <li key={f}>{f}</li>
-                ))}
-              </ul>
-            </div>
-          )}
+      {profile.allowed_fields &&
+        Object.keys(profile.allowed_fields).length > 0 && (
+          <div>
+            <p className="font-medium">Campos permitidos:</p>
+            {Object.entries(profile.allowed_fields).map(([table, fields]) => (
+              <div key={table} className="mt-2">
+                <p className="font-medium">{table}</p>
+                <ul className="list-disc list-inside">
+                  {Object.entries(fields as any).map(([f, allowed]: any) => (
+                    <li key={f}>{f}: {allowed ? 'on' : 'off'}</li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
         </div>
       )}
     </div>

--- a/pages/api/company-users.ts
+++ b/pages/api/company-users.ts
@@ -6,9 +6,27 @@ const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string;
 
 const supabase = createClient(supabaseUrl, serviceRoleKey);
 
+const defaultScopes = {
+  dashboard: true,
+  employees: true,
+  recruitment: true,
+  metrics: true,
+  users: true,
+};
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'POST') {
-    const { email, password, name, phone, position, role, scopes, company_id } = req.body;
+    const {
+      email,
+      password,
+      name,
+      phone,
+      position,
+      role,
+      scopes,
+      allowed_fields,
+      company_id,
+    } = req.body;
 
     const { data: userData, error: authError } = await supabase.auth.admin.createUser({
       email,
@@ -24,29 +42,58 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const userId = userData.user.id;
 
-    const { error: profileError } = await supabase
-      .from('users')
-      .insert({ id: userId, name, email, phone, company_id });
+    const allowedFieldsPayload =
+      allowed_fields && Object.keys(allowed_fields).length > 0
+        ? allowed_fields
+        : null;
 
-    if (profileError) {
-      return res.status(400).json({ error: profileError.message });
-    }
+    const mergedScopes = { ...defaultScopes, ...(scopes || {}) };
 
     const { data: companyUser, error: insertError } = await supabase
       .from('companies_users')
-      .insert({ company_id, user_id: userId, name, email, phone, position, role, scopes })
-      .select('user_id,name,email,phone,position,role,scopes')
+      .insert({
+        company_id,
+        user_id: userId,
+        name,
+        email,
+        phone,
+        position,
+        role,
+        scopes: mergedScopes,
+        allowed_fields: allowedFieldsPayload,
+        updated_at: new Date().toISOString(),
+      })
+      .select('user_id,name,email,phone,position,role,scopes,allowed_fields')
       .single();
 
     if (insertError) {
       return res.status(400).json({ error: insertError.message });
     }
 
-    return res.status(200).json({ user: companyUser });
+    const parsedUser = {
+      ...companyUser,
+      allowed_fields:
+        typeof companyUser.allowed_fields === 'string'
+          ? JSON.parse(companyUser.allowed_fields)
+          : companyUser.allowed_fields,
+    };
+
+    return res.status(200).json({ user: parsedUser });
   }
 
   if (req.method === 'PUT') {
-    const { user_id, company_id, name, email, phone, position, password, role, scopes } = req.body;
+    const {
+      user_id,
+      company_id,
+      name,
+      email,
+      phone,
+      position,
+      password,
+      role,
+      scopes,
+      allowed_fields,
+    } = req.body;
 
     const updateAuthPayload: any = {
       email,
@@ -67,41 +114,47 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(400).json({ error: updateAuthError.message });
     }
 
-    const { error: updateProfileError } = await supabase
-      .from('users')
-      .update({ name, email, phone })
-      .eq('id', user_id);
+    const allowedFieldsPayload =
+      allowed_fields && Object.keys(allowed_fields).length > 0
+        ? allowed_fields
+        : null;
 
-    if (updateProfileError) {
-      return res.status(400).json({ error: updateProfileError.message });
-    }
+    const mergedScopes = { ...defaultScopes, ...(scopes || {}) };
 
     const { data: updatedUser, error: updateError } = await supabase
       .from('companies_users')
-      .update({ name, email, phone, position, role, scopes })
+      .update({
+        name,
+        email,
+        phone,
+        position,
+        role,
+        scopes: mergedScopes,
+        allowed_fields: allowedFieldsPayload,
+        updated_at: new Date().toISOString(),
+      })
       .eq('company_id', company_id)
       .eq('user_id', user_id)
-      .select('user_id,name,email,phone,position,role,scopes')
+      .select('user_id,name,email,phone,position,role,scopes,allowed_fields')
       .single();
 
     if (updateError) {
       return res.status(400).json({ error: updateError.message });
     }
 
-    return res.status(200).json({ user: updatedUser });
+    const parsedUser = {
+      ...updatedUser,
+      allowed_fields:
+        typeof updatedUser.allowed_fields === 'string'
+          ? JSON.parse(updatedUser.allowed_fields)
+          : updatedUser.allowed_fields,
+    };
+
+    return res.status(200).json({ user: parsedUser });
   }
 
   if (req.method === 'DELETE') {
     const { user_id, company_id } = req.body;
-
-    const { error: deleteProfileError } = await supabase
-      .from('users')
-      .delete()
-      .eq('id', user_id);
-
-    if (deleteProfileError) {
-      return res.status(400).json({ error: deleteProfileError.message });
-    }
 
     const { error: deleteCompanyUserError } = await supabase
       .from('companies_users')

--- a/pages/employees/index.tsx
+++ b/pages/employees/index.tsx
@@ -50,6 +50,7 @@ export default function Employees() {
   const [counts, setCounts] = useState({ active: 0, inactive: 0, dismissed: 0 });
   const [units, setUnits] = useState<string[]>([]);
   const [unitFilter, setUnitFilter] = useState('');
+  const [companyId, setCompanyId] = useState('');
   const [field, setField] = useState('');
   const [value, setValue] = useState('');
   const [textValue, setTextValue] = useState('');
@@ -105,7 +106,7 @@ export default function Employees() {
       data: { session },
     } = await supabase.auth.getSession();
     if (!session) return;
-    let companyId = '';
+    let compId = '';
     let unitName = '';
 
     const { data: profile } = await supabase
@@ -115,7 +116,7 @@ export default function Employees() {
       .maybeSingle();
 
     if (profile) {
-      companyId = profile.company_id;
+      compId = profile.company_id;
     } else {
       const { data: compUser } = await supabase
         .from('companies_users')
@@ -123,23 +124,23 @@ export default function Employees() {
         .eq('user_id', session.user.id)
         .maybeSingle();
       if (compUser) {
-        companyId = compUser.company_id;
+        compId = compUser.company_id;
       } else {
         const { data: unitUser } = await supabase
           .from('companies_units')
           .select('company_id,name')
           .eq('user_id', session.user.id)
           .maybeSingle();
-        companyId = unitUser?.company_id || '';
+        compId = unitUser?.company_id || '';
         unitName = unitUser?.name || '';
         if (unitName) setUnitFilter(unitName);
       }
 
-      if (companyId) {
+      if (compId) {
         await supabase.from('users').upsert(
           {
             id: session.user.id,
-            company_id: companyId,
+            company_id: compId,
             name: (session.user.user_metadata as any)?.name || '',
             email: session.user.email,
             phone: (session.user.user_metadata as any)?.phone || '',
@@ -149,11 +150,12 @@ export default function Employees() {
       }
     }
 
-    if (!companyId) return;
+    setCompanyId(compId);
+    if (!compId) return;
     const { data: defs } = await supabase
       .from('custom_fields')
       .select('field,value')
-      .eq('company_id', companyId);
+      .eq('company_id', compId);
     const defMap: Record<string, string[]> = {};
     defs?.forEach((d: any) => {
       defMap[d.field] = defMap[d.field] ? [...defMap[d.field], d.value] : [d.value];
@@ -165,19 +167,19 @@ export default function Employees() {
       const res = await supabase
         .from('employees')
         .select('*')
-        .eq('company_id', companyId)
+        .eq('company_id', compId)
         .eq('unit', unitName);
       data = res.data || [];
     } else {
       const { data: unitRows } = await supabase
         .from('companies_units')
         .select('name')
-        .eq('company_id', companyId);
+        .eq('company_id', compId);
       setUnits(unitRows?.map((u: any) => u.name) || []);
       const res = await supabase
         .from('employees')
         .select('*')
-        .eq('company_id', companyId);
+        .eq('company_id', compId);
       data = res.data || [];
     }
     const expanded = data.map((emp) => ({ ...emp, ...emp.custom_fields }));
@@ -205,6 +207,7 @@ export default function Employees() {
     const { data: viewRows } = await supabase
       .from('employee_views')
       .select('*')
+      .eq('company_id', compId)
       .eq('user_id', session.user.id)
       .order('created_at', { ascending: true });
     let view = viewRows && viewRows.length ? viewRows[0] : null;
@@ -213,6 +216,7 @@ export default function Employees() {
       const { data: created } = await supabase
         .from('employee_views')
         .insert({
+          company_id: compId,
           user_id: session.user.id,
           name: 'Principal',
           columns: defaultViewCols,
@@ -252,6 +256,7 @@ export default function Employees() {
     const { data: created } = await supabase
       .from('employee_views')
       .insert({
+        company_id: companyId,
         user_id: session.user.id,
         name,
         columns: defaultViewCols,
@@ -267,7 +272,11 @@ export default function Employees() {
     const target = views.find((v) => v.id === id);
     if (!target || target.name === 'Principal') return;
     if (!confirm('Excluir esta lista?')) return;
-    await supabase.from('employee_views').delete().eq('id', id);
+    await supabase
+      .from('employee_views')
+      .delete()
+      .eq('company_id', companyId)
+      .eq('id', id);
     setViews((vs) => vs.filter((v) => v.id !== id));
     if (currentView?.id === id) {
       const next = views.find((v) => v.id !== id) || null;
@@ -283,6 +292,7 @@ export default function Employees() {
       await supabase
         .from('employee_views')
         .update({ columns: newCols })
+        .eq('company_id', companyId)
         .eq('id', currentView.id);
       setCurrentView({ ...currentView, columns: newCols });
       setViews((vs) =>
@@ -350,6 +360,7 @@ export default function Employees() {
       await supabase
         .from('employee_views')
         .update({ filters: newFilters })
+        .eq('company_id', companyId)
         .eq('id', currentView.id);
       setCurrentView({ ...currentView, filters: newFilters });
       setViews((vs) =>
@@ -365,6 +376,7 @@ export default function Employees() {
       await supabase
         .from('employee_views')
         .update({ filters: newFilters })
+        .eq('company_id', companyId)
         .eq('id', currentView.id);
       setCurrentView({ ...currentView, filters: newFilters });
       setViews((vs) =>

--- a/pages/users/index.tsx
+++ b/pages/users/index.tsx
@@ -4,6 +4,8 @@ import { supabase } from '../../lib/supabaseClient';
 import { Input } from '../../components/ui/input';
 import { Button } from '../../components/ui/button';
 import PositionSidebar from '../../components/PositionSidebar';
+import ModulePermissionCard from '../../components/ModulePermissionCard';
+import FieldPermissionsModal from '../../components/FieldPermissionsModal';
 
 interface CompanyUser {
   user_id: string;
@@ -12,7 +14,8 @@ interface CompanyUser {
   phone: string;
   position: string | null;
   role: string;
-  scopes: { [key: string]: boolean };
+  scopes: { [key: string]: any };
+  allowed_fields?: { [table: string]: { [field: string]: boolean } };
 }
 
 interface CompanyUnit {
@@ -22,6 +25,14 @@ interface CompanyUnit {
   phone: string;
 }
 
+const defaultScopes = {
+  dashboard: true,
+  employees: true,
+  recruitment: true,
+  metrics: true,
+  users: true,
+};
+
 export default function CompanyUsersPage() {
   const [tab, setTab] = useState<'users' | 'units'>('users');
   const [users, setUsers] = useState<CompanyUser[]>([]);
@@ -29,6 +40,9 @@ export default function CompanyUsersPage() {
   const [companyId, setCompanyId] = useState('');
   const [positions, setPositions] = useState<string[]>([]);
   const [posOpen, setPosOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [creatingUser, setCreatingUser] = useState(false);
+  const [creatingUnit, setCreatingUnit] = useState(false);
 
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -36,8 +50,11 @@ export default function CompanyUsersPage() {
   const [password, setPassword] = useState('');
   const [position, setPosition] = useState('');
   const [role, setRole] = useState('viewer');
-  const [scopes, setScopes] = useState<{ [key: string]: boolean }>({});
+  const [scopes, setScopes] = useState<any>({ ...defaultScopes });
+  const [allowedFields, setAllowedFields] = useState<{ [table: string]: { [field: string]: boolean } }>({ employees: {} });
   const [editingId, setEditingId] = useState<string | null>(null);
+  const [fieldsOpen, setFieldsOpen] = useState(false);
+  const [showMsg, setShowMsg] = useState(false);
 
   const [uName, setUName] = useState('');
   const [uEmail, setUEmail] = useState('');
@@ -46,9 +63,11 @@ export default function CompanyUsersPage() {
   const [unitEditingId, setUnitEditingId] = useState<string | null>(null);
 
   const scopeLabels: Record<string, string> = {
+    dashboard: 'Dashboard',
     employees: 'Funcionários',
-    metrics: 'Métricas',
     recruitment: 'R&S',
+    metrics: 'Métricas',
+    users: 'Usuários',
   };
 
   const roleLabels: Record<string, string> = {
@@ -58,9 +77,9 @@ export default function CompanyUsersPage() {
     viewer: 'Visualizador',
   };
 
-  const formatScopes = (s: { [key: string]: boolean }) =>
-    Object.keys(s || {})
-      .filter((k) => s[k])
+  const formatScopes = (s: { [key: string]: any }) =>
+    Object.keys(defaultScopes)
+      .filter((k) => (s || {})[k] !== false)
       .map((k) => scopeLabels[k] || k)
       .join(', ');
 
@@ -86,9 +105,17 @@ export default function CompanyUsersPage() {
 
       const { data: companyUsers } = await supabase
         .from('companies_users')
-        .select('user_id,name,email,phone,position,role,scopes')
+        .select('user_id,name,email,phone,position,role,scopes,allowed_fields')
         .eq('company_id', compId);
-      setUsers(companyUsers || []);
+      setUsers(
+        (companyUsers || []).map((u: any) => ({
+          ...u,
+          allowed_fields:
+            typeof u.allowed_fields === 'string'
+              ? JSON.parse(u.allowed_fields)
+              : u.allowed_fields,
+        }))
+      );
 
       const { data: companyUnits } = await supabase
         .from('companies_units')
@@ -98,6 +125,50 @@ export default function CompanyUsersPage() {
     };
     load();
   }, []);
+
+  const startCreateUser = () => {
+    setCreatingUser(true);
+    setEditingId(null);
+    setName('');
+    setEmail('');
+    setPhone('');
+    setPassword('');
+    setPosition('');
+    setRole('viewer');
+    setScopes({ ...defaultScopes });
+    setAllowedFields({ employees: {} });
+  };
+
+  const closeUserForm = () => {
+    setCreatingUser(false);
+    setEditingId(null);
+    setName('');
+    setEmail('');
+    setPhone('');
+    setPassword('');
+    setPosition('');
+    setRole('viewer');
+    setScopes({ ...defaultScopes });
+    setAllowedFields({ employees: {} });
+  };
+
+  const startCreateUnit = () => {
+    setCreatingUnit(true);
+    setUnitEditingId(null);
+    setUName('');
+    setUEmail('');
+    setUPhone('');
+    setUPassword('');
+  };
+
+  const closeUnitForm = () => {
+    setCreatingUnit(false);
+    setUnitEditingId(null);
+    setUName('');
+    setUEmail('');
+    setUPhone('');
+    setUPassword('');
+  };
 
   const saveUser = async () => {
     const method = editingId ? 'PUT' : 'POST';
@@ -113,6 +184,7 @@ export default function CompanyUsersPage() {
         position,
         role,
         scopes,
+        allowed_fields: allowedFields,
         company_id: companyId,
       }),
     });
@@ -120,30 +192,34 @@ export default function CompanyUsersPage() {
     if (data.error) {
       alert(data.error);
     } else {
+      const returned = {
+        ...data.user,
+        allowed_fields:
+          typeof data.user.allowed_fields === 'string'
+            ? JSON.parse(data.user.allowed_fields)
+            : data.user.allowed_fields,
+      };
       if (editingId) {
-        setUsers(users.map((u) => (u.user_id === editingId ? data.user : u)));
+        setUsers(users.map((u) => (u.user_id === editingId ? returned : u)));
       } else {
-        setUsers([...users, data.user]);
+        setUsers([...users, returned]);
       }
-      setEditingId(null);
-      setName('');
-      setEmail('');
-      setPhone('');
-      setPassword('');
-      setPosition('');
-      setRole('viewer');
-      setScopes({});
+      closeUserForm();
+      setShowMsg(true);
+      setTimeout(() => setShowMsg(false), 3000);
     }
   };
 
   const startEdit = (u: CompanyUser) => {
+    setCreatingUser(false);
     setEditingId(u.user_id);
     setName(u.name);
     setEmail(u.email);
     setPhone(u.phone);
     setPosition(u.position || '');
     setRole(u.role || 'viewer');
-    setScopes(u.scopes || {});
+    setScopes({ ...defaultScopes, ...(u.scopes || {}) });
+    setAllowedFields({ employees: {}, ...(u.allowed_fields || {}) });
   };
 
   const deleteUser = async (user_id: string) => {
@@ -158,6 +234,48 @@ export default function CompanyUsersPage() {
       alert(data.error);
     } else {
       setUsers(users.filter((u) => u.user_id !== user_id));
+      if (editingId === user_id) {
+        closeUserForm();
+      }
+    }
+  };
+
+  const handleFieldsSave = async (val: { [field: string]: boolean }) => {
+    const updated = { ...allowedFields, employees: val };
+    setAllowedFields(updated);
+    if (editingId) {
+      const res = await fetch('/api/company-users', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          user_id: editingId,
+          email,
+          name,
+          phone,
+          position,
+          role,
+          scopes,
+          allowed_fields: updated,
+          company_id: companyId,
+        }),
+      });
+      const data = await res.json();
+      if (data.error) {
+        alert(data.error);
+      } else {
+        const returned = {
+          ...data.user,
+          allowed_fields:
+            typeof data.user.allowed_fields === 'string'
+              ? JSON.parse(data.user.allowed_fields)
+              : data.user.allowed_fields,
+        };
+        setUsers(
+          users.map((u) => (u.user_id === editingId ? returned : u))
+        );
+        setShowMsg(true);
+        setTimeout(() => setShowMsg(false), 3000);
+      }
     }
   };
 
@@ -184,15 +302,14 @@ export default function CompanyUsersPage() {
       } else {
         setUnits([...units, data.user]);
       }
-      setUnitEditingId(null);
-      setUName('');
-      setUEmail('');
-      setUPhone('');
-      setUPassword('');
+      closeUnitForm();
+      setShowMsg(true);
+      setTimeout(() => setShowMsg(false), 3000);
     }
   };
 
   const startEditUnit = (u: CompanyUnit) => {
+    setCreatingUnit(false);
     setUnitEditingId(u.user_id);
     setUName(u.name);
     setUEmail(u.email);
@@ -211,207 +328,238 @@ export default function CompanyUsersPage() {
       alert(data.error);
     } else {
       setUnits(units.filter((u) => u.user_id !== user_id));
+      if (unitEditingId === user_id) {
+        closeUnitForm();
+      }
     }
   };
+
+  const filteredUsers = users.filter(
+    (u) =>
+      u.name.toLowerCase().includes(search.toLowerCase()) ||
+      u.email.toLowerCase().includes(search.toLowerCase())
+  );
+  const filteredUnits = units.filter(
+    (u) =>
+      u.name.toLowerCase().includes(search.toLowerCase()) ||
+      u.email.toLowerCase().includes(search.toLowerCase())
+  );
 
   return (
     <Layout>
       <div className="mb-8">
         <h1 className="text-2xl font-bold mb-4">Usuários & Permissões</h1>
-      <div className="mb-4 flex gap-2">
-        <Button variant={tab === 'users' ? 'default' : 'outline'} onClick={() => setTab('users')}>
-          Usuários
-        </Button>
-        <Button variant={tab === 'units' ? 'default' : 'outline'} onClick={() => setTab('units')}>
-          Unidades
-        </Button>
-      </div>
-      {tab === 'users' ? (
-        <>
-            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 mb-4">
-              <Input placeholder="Nome" value={name} onChange={(e) => setName(e.target.value)} />
-              <Input placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
-              <Input placeholder="Telefone" value={phone} onChange={(e) => setPhone(e.target.value)} />
-              <Input
-                placeholder="Senha"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-              />
-              <div className="flex items-center gap-2">
-                <select
-                  className="border p-2 rounded w-full"
-                  value={position}
-                  onChange={(e) => setPosition(e.target.value)}
+
+        <div className="mb-4 border-b flex">
+          <button
+            className={`px-4 py-2 -mb-px ${tab === 'users' ? 'border-b-2 border-black' : 'text-gray-500'}`}
+            onClick={() => {
+              setTab('users');
+              setSearch('');
+              setCreatingUser(false);
+              setCreatingUnit(false);
+              setEditingId(null);
+              setUnitEditingId(null);
+            }}
+          >
+            Usuários
+          </button>
+          <button
+            className={`px-4 py-2 -mb-px ${tab === 'units' ? 'border-b-2 border-black' : 'text-gray-500'}`}
+            onClick={() => {
+              setTab('units');
+              setSearch('');
+              setCreatingUser(false);
+              setCreatingUnit(false);
+              setEditingId(null);
+              setUnitEditingId(null);
+            }}
+          >
+            Unidades
+          </button>
+        </div>
+
+        <div className="flex gap-2 mb-4 items-end">
+          <div className="flex-1">
+            <label className="block text-sm font-medium mb-1">Pesquisar</label>
+            <Input value={search} onChange={(e) => setSearch(e.target.value)} />
+          </div>
+          <Button onClick={tab === 'users' ? startCreateUser : startCreateUnit}>
+            {tab === 'users' ? 'Criar usuário' : 'Criar unidade'}
+          </Button>
+        </div>
+
+        {tab === 'users' ? (
+          <div className="flex gap-4">
+            <div className="w-1/3 space-y-2">
+              {filteredUsers.map((u) => (
+                <div
+                  key={u.user_id}
+                  onClick={() => startEdit(u)}
+                  className={`border p-2 rounded cursor-pointer ${
+                    editingId === u.user_id && !creatingUser ? 'bg-gray-100' : ''
+                  }`}
                 >
-                  <option value="">Cargo</option>
-                  {positions.map((p) => (
-                    <option key={p} value={p}>
-                      {p}
-                    </option>
-                  ))}
-                </select>
-                <Button type="button" variant="outline" size="sm" onClick={() => setPosOpen(true)}>
-                  Cargos
-                </Button>
-              </div>
-              <select
-                className="border p-2 rounded w-full"
-                value={role}
-                onChange={(e) => setRole(e.target.value)}
-              >
-                <option value="admin">Administrador</option>
-                <option value="manager">Gestor</option>
-                <option value="recruiter">Recrutador</option>
-                <option value="viewer">Visualizador</option>
-              </select>
-              <div className="sm:col-span-2 lg:col-span-3 flex gap-4">
-                <label className="flex items-center gap-1">
-                  <input
-                    type="checkbox"
-                    checked={scopes.employees || false}
-                    onChange={(e) => setScopes({ ...scopes, employees: e.target.checked })}
-                  />
-                  Funcionários
-                </label>
-                <label className="flex items-center gap-1">
-                  <input
-                    type="checkbox"
-                    checked={scopes.metrics || false}
-                    onChange={(e) => setScopes({ ...scopes, metrics: e.target.checked })}
-                  />
-                  Métricas
-                </label>
-                <label className="flex items-center gap-1">
-                  <input
-                    type="checkbox"
-                    checked={scopes.recruitment || false}
-                    onChange={(e) =>
-                      setScopes({ ...scopes, recruitment: e.target.checked })
-                    }
-                  />
-                  R&S
-                </label>
-              </div>
-              <div className="sm:col-span-2 lg:col-span-3 flex gap-2">
-                <Button onClick={saveUser} disabled={!name || !email || (!password && !editingId)}>
-                  {editingId ? 'Salvar' : 'Adicionar'}
-                </Button>
-                {editingId && (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => {
-                      setEditingId(null);
-                      setName('');
-                      setEmail('');
-                      setPhone('');
-                      setPassword('');
-                      setPosition('');
-                      setRole('viewer');
-                      setScopes({});
-                    }}
-                  >
-                    Cancelar
-                  </Button>
-                )}
-              </div>
+                  <div className="font-semibold">{u.name}</div>
+                  <div className="text-sm text-gray-600">{u.email}</div>
+                  <div className="text-xs text-gray-500">
+                    {formatScopes(u.scopes)}
+                  </div>
+                </div>
+              ))}
             </div>
-            <table className="w-full text-left border">
-              <thead>
-                <tr className="border-b">
-                  <th className="p-2">Nome</th>
-                  <th className="p-2">Email</th>
-                  <th className="p-2">Telefone</th>
-                  <th className="p-2">Cargo</th>
-                  <th className="p-2">Papel</th>
-                  <th className="p-2">Módulos</th>
-                  <th className="p-2">Ações</th>
-                </tr>
-              </thead>
-              <tbody>
-                {users.map((u) => (
-                  <tr key={u.user_id} className="border-b">
-                    <td className="p-2">{u.name}</td>
-                    <td className="p-2">{u.email}</td>
-                    <td className="p-2">{u.phone}</td>
-                    <td className="p-2">{u.position}</td>
-                    <td className="p-2">{roleLabels[u.role] || u.role}</td>
-                    <td className="p-2">{formatScopes(u.scopes)}</td>
-                    <td className="p-2 flex gap-2">
-                      <Button size="sm" variant="outline" onClick={() => startEdit(u)}>
-                        Editar
-                      </Button>
-                      <Button size="sm" variant="destructive" onClick={() => deleteUser(u.user_id)}>
-                        Excluir
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </>
+            <div className="flex-1">
+              {(creatingUser || editingId) && (
+                <div className="space-y-4">
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Nome</label>
+                      <Input value={name} onChange={(e) => setName(e.target.value)} />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Email</label>
+                      <Input type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Telefone</label>
+                      <Input value={phone} onChange={(e) => setPhone(e.target.value)} />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Senha</label>
+                      <Input
+                        type="password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                      />
+                    </div>
+                    <div className="sm:col-span-2">
+                      <label className="block text-sm font-medium mb-1">Cargo</label>
+                      <div className="flex items-center gap-2">
+                        <select
+                          className="border p-2 rounded w-full"
+                          value={position}
+                          onChange={(e) => setPosition(e.target.value)}
+                        >
+                          <option value="">Selecione um cargo</option>
+                          {positions.map((p) => (
+                            <option key={p} value={p}>
+                              {p}
+                            </option>
+                          ))}
+                        </select>
+                        <Button type="button" variant="outline" size="sm" onClick={() => setPosOpen(true)}>
+                          Cargos
+                        </Button>
+                      </div>
+                    </div>
+                    <div className="sm:col-span-2">
+                      <label className="block text-sm font-medium mb-1">Função</label>
+                      <select
+                        className="border p-2 rounded w-full"
+                        value={role}
+                        onChange={(e) => setRole(e.target.value)}
+                      >
+                        {Object.entries(roleLabels).map(([key, label]) => (
+                          <option key={key} value={key}>
+                            {label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <ModulePermissionCard
+                      label="Dashboard"
+                      enabled={scopes.dashboard}
+                      onToggle={(v) => setScopes({ ...scopes, dashboard: v })}
+                    />
+                    <ModulePermissionCard
+                      label="Funcionários"
+                      enabled={scopes.employees}
+                      onToggle={(v) => setScopes({ ...scopes, employees: v })}
+                      onConfig={() => setFieldsOpen(true)}
+                    />
+                    <ModulePermissionCard
+                      label="R&S"
+                      enabled={scopes.recruitment}
+                      onToggle={(v) => setScopes({ ...scopes, recruitment: v })}
+                    />
+                    <ModulePermissionCard
+                      label="Métricas"
+                      enabled={scopes.metrics}
+                      onToggle={(v) => setScopes({ ...scopes, metrics: v })}
+                    />
+                    <ModulePermissionCard
+                      label="Usuários"
+                      enabled={scopes.users}
+                      onToggle={(v) => setScopes({ ...scopes, users: v })}
+                    />
+                  </div>
+                  <div className="flex gap-2">
+                    <Button onClick={saveUser} disabled={!name || !email || (!password && !editingId)}>
+                      {editingId ? 'Salvar' : 'Adicionar'}
+                    </Button>
+                    <Button type="button" variant="outline" onClick={closeUserForm}>
+                      Cancelar
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
         ) : (
-          <>
-            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 mb-4">
-              <Input placeholder="Nome" value={uName} onChange={(e) => setUName(e.target.value)} />
-              <Input placeholder="Email" value={uEmail} onChange={(e) => setUEmail(e.target.value)} />
-              <Input placeholder="Telefone" value={uPhone} onChange={(e) => setUPhone(e.target.value)} />
-              <Input
-                placeholder="Senha"
-                type="password"
-                value={uPassword}
-                onChange={(e) => setUPassword(e.target.value)}
-              />
-              <div className="sm:col-span-2 lg:col-span-3 flex gap-2">
-                <Button onClick={saveUnit} disabled={!uName || !uEmail || (!uPassword && !unitEditingId)}>
-                  {unitEditingId ? 'Salvar' : 'Adicionar'}
-                </Button>
-                {unitEditingId && (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={() => {
-                      setUnitEditingId(null);
-                      setUName('');
-                      setUEmail('');
-                      setUPhone('');
-                      setUPassword('');
-                    }}
-                  >
-                    Cancelar
-                  </Button>
-                )}
-              </div>
+          <div className="flex gap-4">
+            <div className="w-1/3 space-y-2">
+              {filteredUnits.map((u) => (
+                <div
+                  key={u.user_id}
+                  onClick={() => startEditUnit(u)}
+                  className={`border p-2 rounded cursor-pointer ${
+                    unitEditingId === u.user_id && !creatingUnit ? 'bg-gray-100' : ''
+                  }`}
+                >
+                  <div className="font-semibold">{u.name}</div>
+                  <div className="text-sm text-gray-600">{u.email}</div>
+                </div>
+              ))}
             </div>
-            <table className="w-full text-left border">
-              <thead>
-                <tr className="border-b">
-                  <th className="p-2">Nome</th>
-                  <th className="p-2">Email</th>
-                  <th className="p-2">Telefone</th>
-                  <th className="p-2">Ações</th>
-                </tr>
-              </thead>
-              <tbody>
-                {units.map((u) => (
-                  <tr key={u.user_id} className="border-b">
-                    <td className="p-2">{u.name}</td>
-                    <td className="p-2">{u.email}</td>
-                    <td className="p-2">{u.phone}</td>
-                    <td className="p-2 flex gap-2">
-                      <Button size="sm" variant="outline" onClick={() => startEditUnit(u)}>
-                        Editar
-                      </Button>
-                      <Button size="sm" variant="destructive" onClick={() => deleteUnit(u.user_id)}>
-                        Excluir
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </>
+            <div className="flex-1">
+              {(creatingUnit || unitEditingId) && (
+                <div className="space-y-4">
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Nome</label>
+                      <Input value={uName} onChange={(e) => setUName(e.target.value)} />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Email</label>
+                      <Input type="email" value={uEmail} onChange={(e) => setUEmail(e.target.value)} />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Telefone</label>
+                      <Input value={uPhone} onChange={(e) => setUPhone(e.target.value)} />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Senha</label>
+                      <Input
+                        type="password"
+                        value={uPassword}
+                        onChange={(e) => setUPassword(e.target.value)}
+                      />
+                    </div>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button onClick={saveUnit} disabled={!uName || !uEmail || (!uPassword && !unitEditingId)}>
+                      {unitEditingId ? 'Salvar' : 'Adicionar'}
+                    </Button>
+                    <Button type="button" variant="outline" onClick={closeUnitForm}>
+                      Cancelar
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
         )}
       </div>
       <PositionSidebar
@@ -425,6 +573,18 @@ export default function CompanyUsersPage() {
             .then(({ data }) => setPositions(data?.map((p: any) => p.name) || []));
         }}
       />
+      <FieldPermissionsModal
+        open={fieldsOpen}
+        onClose={() => setFieldsOpen(false)}
+        table="employees"
+        value={allowedFields.employees || {}}
+        onSave={handleFieldsSave}
+      />
+      {showMsg && (
+        <div className="fixed top-4 right-4 bg-green-100 border border-green-400 text-green-800 px-4 py-2 rounded">
+          Alterações salvas com sucesso
+        </div>
+      )}
     </Layout>
   );
 }

--- a/supabase.sql
+++ b/supabase.sql
@@ -66,11 +66,32 @@ create table public.positions (
 
 create table public.employee_views (
   id uuid primary key default uuid_generate_v4(),
+  company_id uuid references public.companies(id) on delete cascade,
   user_id uuid references public.users(id) on delete cascade,
   name text not null,
   columns text[],
   filters jsonb,
   created_at timestamptz default now()
+);
+
+create table public.employee_filters (
+  id uuid primary key default uuid_generate_v4(),
+  company_id uuid references public.companies(id) on delete cascade,
+  user_id uuid references public.users(id) on delete cascade,
+  name text not null,
+  filters jsonb,
+  created_at timestamptz default now()
+);
+
+create table public.payment_webhook_log (
+  id bigserial primary key,
+  company_id uuid references public.companies(id) on delete cascade,
+  provider text not null,
+  received_at timestamptz default now(),
+  event_type text,
+  body jsonb,
+  headers jsonb,
+  ip text
 );
 
 create table public.subscriptions (
@@ -81,3 +102,35 @@ create table public.subscriptions (
   status text default 'pending',
   created_at timestamptz default now()
 );
+
+-- ensure companies_users has an updated_at column for triggers that rely on it
+alter table if exists public.companies_users
+  add column if not exists updated_at timestamptz default now();
+
+alter table if exists public.employee_views
+  add column if not exists company_id uuid references public.companies(id) on delete cascade;
+
+alter table if exists public.employee_filters
+  add column if not exists company_id uuid references public.companies(id) on delete cascade;
+
+alter table if exists public.payment_webhook_log
+  add column if not exists company_id uuid references public.companies(id) on delete cascade;
+
+-- default scopes grant full module access unless explicitly disabled
+alter table if exists public.companies_users
+  alter column scopes set default '{
+    "dashboard": true,
+    "employees": true,
+    "recruitment": true,
+    "metrics": true,
+    "users": true
+  }'::jsonb;
+
+update public.companies_users
+set scopes = '{
+  "dashboard": true,
+  "employees": true,
+  "recruitment": true,
+  "metrics": true,
+  "users": true
+}'::jsonb || coalesce(scopes, '{}'::jsonb);

--- a/supabaserecrutamento.sql
+++ b/supabaserecrutamento.sql
@@ -48,6 +48,7 @@ create table if not exists talent_tags (
 create table if not exists talent_tag_map (
   talent_id uuid references talents(id) on delete cascade,
   tag_id uuid references talent_tags(id) on delete cascade,
+  company_id uuid references companies(id) on delete cascade,
   primary key (talent_id,tag_id)
 );
 
@@ -61,6 +62,7 @@ create table if not exists skills (
 create table if not exists talent_skill_map (
   talent_id uuid references talents(id) on delete cascade,
   skill_id uuid references skills(id) on delete cascade,
+  company_id uuid references companies(id) on delete cascade,
   primary key (talent_id,skill_id)
 );
 
@@ -118,6 +120,7 @@ create table if not exists job_stages (
 
 create table if not exists job_metrics (
   job_id uuid primary key references jobs(id) on delete cascade,
+  company_id uuid not null references companies(id) on delete cascade,
   link_clicks int default 0,
   closing_time numeric
 );
@@ -139,6 +142,7 @@ create table if not exists job_script_configs (
 create table if not exists job_scripts (
   id uuid primary key default uuid_generate_v4(),
   job_id uuid not null references jobs(id) on delete cascade,
+  company_id uuid not null references companies(id) on delete cascade,
   template_id uuid references job_script_configs(id),
   name text not null,
   content text default '',
@@ -208,6 +212,7 @@ create table if not exists application_stage_history (
 create table if not exists application_stage_dates (
   application_id uuid not null references applications(id) on delete cascade,
   stage_id uuid not null references job_stages(id) on delete cascade,
+  company_id uuid not null references companies(id) on delete cascade,
   day_in timestamptz not null,
   day_out timestamptz,
   primary key (application_id, stage_id)
@@ -232,6 +237,21 @@ create table if not exists reports_cache (
   value numeric not null,
   primary key (company_id,metric,period_start,period_end)
 );
+
+alter table if exists talent_tag_map
+  add column if not exists company_id uuid references companies(id) on delete cascade;
+
+alter table if exists talent_skill_map
+  add column if not exists company_id uuid references companies(id) on delete cascade;
+
+alter table if exists job_metrics
+  add column if not exists company_id uuid references companies(id) on delete cascade;
+
+alter table if exists job_scripts
+  add column if not exists company_id uuid references companies(id) on delete cascade;
+
+alter table if exists application_stage_dates
+  add column if not exists company_id uuid references companies(id) on delete cascade;
 
 -- RLS policies
 alter table talents enable row level security;
@@ -282,3 +302,22 @@ create policy read_all on applications for select using (company_id = (auth.jwt(
 create policy read_all on job_scripts for select using (exists (select 1 from jobs j where j.id = job_scripts.job_id and j.company_id = (auth.jwt() ->> 'company_id')::uuid));
 create policy read_all on job_script_configs for select using (company_id = (auth.jwt() ->> 'company_id')::uuid);
 create policy read_all on job_form_configs for select using (company_id = (auth.jwt() ->> 'company_id')::uuid);
+
+-- ensure companies_users scopes default to full access
+alter table if exists public.companies_users
+  alter column scopes set default '{
+    "dashboard": true,
+    "employees": true,
+    "recruitment": true,
+    "metrics": true,
+    "users": true
+  }'::jsonb;
+
+update public.companies_users
+set scopes = '{
+  "dashboard": true,
+  "employees": true,
+  "recruitment": true,
+  "metrics": true,
+  "users": true
+}'::jsonb || coalesce(scopes, '{}'::jsonb);


### PR DESCRIPTION
## Summary
- Redesign the users page with tab navigation for users and units
- Add search bar and create button in top bar
- List existing entries as selectable cards with side-by-side edit form
- Introduce default-on access toggles for dashboard, employees, recruitment, metrics and users
- Filter sidebar links and redirect when a scope is disabled
- Replace simple scope checkboxes with card-based module toggles and a configuration modal
- Allow configuring employee field visibility with per-column on/off switches and Portuguese labels
- Persist field permissions to `companies_users.allowed_fields` for future per-table configurations
- Fix persistence by JSON-serializing `allowed_fields` and seeding the modal from saved values
- Store `allowed_fields` as JSON instead of a serialized string to ensure database persistence
- Save field permission changes from the modal immediately to `companies_users.allowed_fields`
- Use toggle buttons to assign roles and save them to `companies_users.role`
- Ensure `companies_users` has an `updated_at` column and set it when creating or updating records
- Remove outdated references to a `users.updated_at` column in schema and API
- Convert permission checkboxes to switch toggles and show a success toast after saving
- Harmonize CRUD form layout on the users page for clearer input grouping
- Add purple-themed switches, labeled form inputs, a role dropdown, and full-width module cards with gear configuration
- Turn module configuration gears into accessible outline buttons
- Add `company_id` references to various auxiliary tables and provide migration alters for existing databases
- Default all module scopes to true in `companies_users` and merge these defaults in the API so company owners retain full access
- Remove `users` table mutations from the company user API so restrictions live solely in `companies_users`

## Testing
- `npm test`
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f9e879ec832da4de8348a3df24b5